### PR TITLE
hotfix: fix claude token build error + codeql v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
       - name: Set up Go
@@ -36,4 +36,4 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/pkg/llmproxy/auth/claude/token.go
+++ b/pkg/llmproxy/auth/claude/token.go
@@ -8,31 +8,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/misc"
 )
-
-func sanitizeTokenFilePath(authFilePath string) (string, error) {
-	trimmed := strings.TrimSpace(authFilePath)
-	if trimmed == "" {
-		return "", fmt.Errorf("token file path is empty")
-	}
-	cleaned := filepath.Clean(trimmed)
-	parts := strings.FieldsFunc(cleaned, func(r rune) bool {
-		return r == '/' || r == '\\'
-	})
-	for _, part := range parts {
-		if part == ".." {
-			return "", fmt.Errorf("invalid token file path")
-		}
-	}
-	absPath, err := filepath.Abs(cleaned)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve token file path: %w", err)
-	}
-	return absPath, nil
-}
 
 // ClaudeTokenStorage stores OAuth2 token information for Anthropic Claude API authentication.
 // It maintains compatibility with the existing auth system while adding Claude-specific fields
@@ -76,10 +54,6 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 	misc.LogSavingCredentials(safePath)
 	ts.Type = "claude"
-	safePath, err := sanitizeTokenFilePath(authFilePath)
-	if err != nil {
-		return err
-	}
 
 	// Create directory structure if it doesn't exist
 	if err = os.MkdirAll(filepath.Dir(safePath), 0700); err != nil {


### PR DESCRIPTION
Fixes post-merge CI failures from PR #195.\n\nChanges:\n- remove duplicate safePath redeclaration in `pkg/llmproxy/auth/claude/token.go`\n- upgrade CodeQL workflow actions from v3 to v4 (`init`, `analyze`)\n\nValidation:\n- go test ./pkg/llmproxy/auth/claude -count=1\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/config update plus a small Go fix removing a duplicate variable/path-sanitization function; runtime behavior should be unchanged aside from using the shared path validation helper.
> 
> **Overview**
> Upgrades the CodeQL GitHub Actions workflow to `github/codeql-action@v4` for both `init` and `analyze`.
> 
> Fixes a Go build issue in Claude token persistence by removing a duplicate `safePath` redeclaration and dropping the local `sanitizeTokenFilePath` helper in favor of the shared `misc.ResolveSafeFilePath` validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 569957f83f561482627066996dda415d6656c70e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->