### PR TITLE
fix: resolve executor compile regressions

### DIFF
--- a/pkg/llmproxy/auth/claude/token.go
+++ b/pkg/llmproxy/auth/claude/token.go
@@ -76,7 +76,7 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	}
 	misc.LogSavingCredentials(safePath)
 	ts.Type = "claude"
-	safePath, err := sanitizeTokenFilePath(authFilePath)
+	safePath, err = sanitizeTokenFilePath(authFilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/llmproxy/executor/codex_websockets_executor.go
+++ b/pkg/llmproxy/executor/codex_websockets_executor.go
@@ -5,8 +5,6 @@ package executor
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -1300,7 +1298,7 @@ func logCodexWebsocketConnected(sessionID string, authID string, wsURL string) {
 	log.Infof("codex websockets: upstream connected session=%s auth=%s url=%s", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL))
 }
 
-func logCodexWebsocketDisconnected(sessionID string, _ string, _ string, reason string, err error) {
+func logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason string, err error) {
 	if err != nil {
 		log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s reason=%s err=%v", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL), strings.TrimSpace(reason), err)
 		return

--- a/pkg/llmproxy/executor/github_copilot_executor.go
+++ b/pkg/llmproxy/executor/github_copilot_executor.go
@@ -545,9 +545,6 @@ func (e *GitHubCopilotExecutor) normalizeModel(model string, body []byte) []byte
 	return body
 }
 
-// CloseExecutionSession implements ProviderExecutor.
-func (e *GitHubCopilotExecutor) CloseExecutionSession(sessionID string) {}
-
 func useGitHubCopilotResponsesEndpoint(sourceFormat sdktranslator.Format, model string) bool {
 	if sourceFormat.String() == "openai-response" {
 		return true

--- a/pkg/llmproxy/executor/kiro_executor.go
+++ b/pkg/llmproxy/executor/kiro_executor.go
@@ -1666,6 +1666,7 @@ func (e *KiroExecutor) mapModelToKiro(model string) string {
 			log.Debug("kiro: unknown Sonnet 4.5 model, mapping to claude-sonnet-4.5")
 			return "claude-sonnet-4.5"
 		}
+	}
 
 	// Check for Opus variants
 	if strings.Contains(modelLower, "opus") {


### PR DESCRIPTION
## Summary
- Fix syntax/parsing issue in  mapModelToKiro block.
- Fix duplicated  method in GitHub Copilot executor.
- Fix Codex websocket disconnect logger variable scope and remove unused imports.
- Fix  short variable redeclare.

## Files changed
- 
- 
- 
- 

## Validation
- go test ./pkg/llmproxy/executor ./pkg/llmproxy/translator/kiro/claude -run TestDoesNotExist -count=0