### PR TITLE
fix(docs): guard unresolved phase placeholder tokens

### DIFF
--- a/.github/scripts/check-phase-doc-placeholder-tokens.sh
+++ b/.github/scripts/check-phase-doc-placeholder-tokens.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Guard against unresolved generator placeholders in planning reports.
+# Allow natural-language "undefined" mentions; block explicit malformed token patterns.
+PATTERN='undefinedBKM-[A-Za-z0-9_-]+|undefined[A-Z0-9_-]+undefined'
+
+if rg -n --pcre2 "$PATTERN" docs/planning/reports -g '*.md'; then
+  echo "[FAIL] unresolved placeholder-like tokens detected in docs/planning/reports"
+  exit 1
+fi
+
+echo "[OK] no unresolved placeholder-like tokens in docs/planning/reports"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -356,12 +356,18 @@ tasks:
     cmds:
       - task: preflight
       - task: quality:docs-open-items-parity
+      - task: quality:docs-phase-placeholders
       - ./.github/scripts/release-lint.sh
 
   quality:docs-open-items-parity:
     desc: "Prevent stale status drift in fragmented open-items report"
     cmds:
       - ./.github/scripts/check-open-items-fragmented-parity.sh
+
+  quality:docs-phase-placeholders:
+    desc: "Reject unresolved placeholder-like tokens in planning reports"
+    cmds:
+      - ./.github/scripts/check-phase-doc-placeholder-tokens.sh
 
   test:smoke:
     desc: "Run smoke tests for startup and control-plane surfaces"

--- a/docs/planning/reports/issue-wave-cp2k-next30-execution-summary-2026-02-23.md
+++ b/docs/planning/reports/issue-wave-cp2k-next30-execution-summary-2026-02-23.md
@@ -16,11 +16,11 @@
 | Lane 5 | CP2K-0051,0052,0053,0054,0056 | Completed; auth watcher hardening + quickstart/runbook additions |
 | Lane 6 | CP2K-0059,0060,0062,0063,0064 | Completed; troubleshooting matrix/test coverage updates |
 
-## Undefined Placeholder Audit
+## Placeholder Token Audit
 
-- Requested issue: generated phase docs showing malformed placeholders like `undefinedBKM-*`.
-- Audit in this repo/worktree: no malformed placeholder tokens found.
-- Found `undefined` only as literal issue text/context in historical reports and compiler diagnostics.
+- Requested issue: generated phase docs showing malformed placeholders such as unresolved backmatter IDs.
+- Audit in this repo/worktree: no malformed tokens like `undefinedBKM-*` were found.
+- Remaining `undefined` strings are literal error-context text in historical reports and compiler diagnostics, not template placeholders.
 
 ## Key Changes Included
 
@@ -53,4 +53,3 @@
 
 - Known unrelated blockers in baseline:
   - package-level compile drift around `normalizeGeminiCLIModel` in unrelated executor tests.
-


### PR DESCRIPTION
## Summary
- add a release-lint guard for unresolved placeholder-like tokens in phase reports
- clarify wording in next30 execution summary so literal error-context "undefined" is not treated as template corruption
- wire new check into `quality:release-lint`

## Validation
- `task quality:docs-phase-placeholders`
- `task quality:release-lint`
