### PR TITLE
fix(security): redact clear-text logging surfaces (wave 1)

### DIFF
--- a/pkg/llmproxy/executor/codex_websockets_executor.go
+++ b/pkg/llmproxy/executor/codex_websockets_executor.go
@@ -5,6 +5,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net"
@@ -1295,15 +1296,15 @@ func (e *CodexWebsocketsExecutor) closeExecutionSession(sess *codexWebsocketSess
 }
 
 func logCodexWebsocketConnected(sessionID string, authID string, wsURL string) {
-	log.Infof("codex websockets: upstream connected session=%s auth=%s url=%s", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL))
+	log.Infof("codex websockets: upstream connected session=%s auth=%s endpoint=%s", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL))
 }
 
 func logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason string, err error) {
 	if err != nil {
-		log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s reason=%s err=%v", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL), strings.TrimSpace(reason), err)
+		log.Infof("codex websockets: upstream disconnected session=%s auth=%s endpoint=%s reason=%s err=%v", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL), strings.TrimSpace(reason), err)
 		return
 	}
-	log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s reason=%s", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL), strings.TrimSpace(reason))
+	log.Infof("codex websockets: upstream disconnected session=%s auth=%s endpoint=%s reason=%s", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL), strings.TrimSpace(reason))
 }
 
 func sanitizeCodexWebsocketLogField(raw string) string {
@@ -1323,6 +1324,27 @@ func sanitizeCodexWebsocketLogURL(raw string) string {
 	parsed.Fragment = ""
 	parsed.RawQuery = util.MaskSensitiveQuery(parsed.RawQuery)
 	return parsed.String()
+}
+
+func sanitizeCodexWebsocketLogEndpoint(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return "redacted-endpoint"
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+func sanitizeCodexSessionID(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return fmt.Sprintf("sess_%x", sum[:6])
 }
 
 // CodexAutoExecutor routes Codex requests to the websocket transport only when:

--- a/pkg/llmproxy/registry/model_registry.go
+++ b/pkg/llmproxy/registry/model_registry.go
@@ -5,6 +5,7 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
@@ -661,7 +662,7 @@ func (r *ModelRegistry) SuspendClientModel(clientID, modelID, reason string) {
 	registration.SuspendedClients[clientID] = reason
 	registration.LastUpdated = time.Now()
 	if reason != "" {
-		log.Debugf("Suspended client %s for model %s (reason provided)", clientID, modelID)
+		log.Debugf("Suspended client %s for model %s (reason provided)", logSafeRegistryID(clientID), logSafeRegistryID(modelID))
 	} else {
 		log.Debug("Suspended client for model")
 	}
@@ -688,6 +689,15 @@ func (r *ModelRegistry) ResumeClientModel(clientID, modelID string) {
 	delete(registration.SuspendedClients, clientID)
 	registration.LastUpdated = time.Now()
 	log.Debug("Resumed suspended client for model")
+}
+
+func logSafeRegistryID(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return fmt.Sprintf("id_%x", sum[:6])
 }
 
 // ClientSupportsModel reports whether the client registered support for modelID.

--- a/pkg/llmproxy/runtime/executor/codex_websockets_executor.go
+++ b/pkg/llmproxy/runtime/executor/codex_websockets_executor.go
@@ -5,6 +5,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net"
@@ -1295,15 +1296,15 @@ func (e *CodexWebsocketsExecutor) closeExecutionSession(sess *codexWebsocketSess
 }
 
 func logCodexWebsocketConnected(sessionID string, authID string, wsURL string) {
-	log.Infof("codex websockets: upstream connected session=%s auth=%s url=%s", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL))
+	log.Infof("codex websockets: upstream connected session=%s auth=%s endpoint=%s", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL))
 }
 
 func logCodexWebsocketDisconnected(sessionID string, authID string, wsURL string, reason string, err error) {
 	if err != nil {
-		log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s reason=%s err=%v", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL), strings.TrimSpace(reason), err)
+		log.Infof("codex websockets: upstream disconnected session=%s auth=%s endpoint=%s reason=%s err=%v", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL), strings.TrimSpace(reason), err)
 		return
 	}
-	log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s reason=%s", strings.TrimSpace(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogURL(wsURL), strings.TrimSpace(reason))
+	log.Infof("codex websockets: upstream disconnected session=%s auth=%s endpoint=%s reason=%s", sanitizeCodexSessionID(sessionID), sanitizeCodexWebsocketLogField(authID), sanitizeCodexWebsocketLogEndpoint(wsURL), strings.TrimSpace(reason))
 }
 
 func sanitizeCodexWebsocketLogField(raw string) string {
@@ -1323,6 +1324,27 @@ func sanitizeCodexWebsocketLogURL(raw string) string {
 	parsed.Fragment = ""
 	parsed.RawQuery = util.MaskSensitiveQuery(parsed.RawQuery)
 	return parsed.String()
+}
+
+func sanitizeCodexWebsocketLogEndpoint(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return "redacted-endpoint"
+	}
+	return parsed.Scheme + "://" + parsed.Host
+}
+
+func sanitizeCodexSessionID(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return fmt.Sprintf("sess_%x", sum[:6])
 }
 
 // CodexAutoExecutor routes Codex requests to the websocket transport only when:


### PR DESCRIPTION
## Summary
- redact raw request/response payload bytes before request logging
- replace websocket log URL/session disclosure with endpoint+hashed session labels
- hash registry client/model IDs in suspension debug logs

## Verification
- go test ./pkg/llmproxy/api/middleware ./pkg/llmproxy/registry
- note: executor package test baseline on main currently has unrelated compile failures (gemini_cli_executor_model_test: normalizeGeminiCLIModel)

## Security
Targets open CodeScanning clear-text logging findings in these files.