### PR TITLE
security(wave2): SSRF protection, path sanitization, keyed hashing (rebased)

### DIFF
--- a/pkg/llmproxy/api/handlers/management/api_tools.go
+++ b/pkg/llmproxy/api/handlers/management/api_tools.go
@@ -151,13 +151,13 @@ func (h *Handler) APICall(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing url"})
 		return
 	}
-	parsedURL, errParseURL := url.Parse(urlStr)
-	if errParseURL != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid url"})
+	safeURL, parsedURL, errSanitizeURL := sanitizeAPICallURL(urlStr)
+	if errSanitizeURL != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errSanitizeURL.Error()})
 		return
 	}
-	if errValidateURL := validateAPICallURL(parsedURL); errValidateURL != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": errValidateURL.Error()})
+	if errResolve := validateResolvedHostIPs(parsedURL.Hostname()); errResolve != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errResolve.Error()})
 		return
 	}
 
@@ -212,7 +212,7 @@ func (h *Handler) APICall(c *gin.Context) {
 		}
 	}
 
-	req, errNewRequest := http.NewRequestWithContext(c.Request.Context(), method, urlStr, requestBody)
+	req, errNewRequest := http.NewRequestWithContext(c.Request.Context(), method, safeURL, requestBody)
 	if errNewRequest != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to build request"})
 		return
@@ -226,6 +226,10 @@ func (h *Handler) APICall(c *gin.Context) {
 		req.Header.Set(key, value)
 	}
 	if hostOverride != "" {
+		if !isAllowedHostOverride(parsedURL, hostOverride) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid host override"})
+			return
+		}
 		req.Host = hostOverride
 	}
 
@@ -268,8 +272,8 @@ func (h *Handler) APICall(c *gin.Context) {
 
 	// If this is a GitHub Copilot token endpoint response, try to enrich with quota information
 	if resp.StatusCode == http.StatusOK &&
-		strings.Contains(urlStr, "copilot_internal") &&
-		strings.Contains(urlStr, "/token") {
+		strings.Contains(safeURL, "copilot_internal") &&
+		strings.Contains(safeURL, "/token") {
 		response = h.enrichCopilotTokenResponse(c.Request.Context(), response, auth, urlStr)
 	}
 
@@ -298,6 +302,35 @@ func firstNonEmptyString(values ...*string) string {
 	return ""
 }
 
+func isAllowedHostOverride(parsedURL *url.URL, override string) bool {
+	if parsedURL == nil {
+		return false
+	}
+	trimmed := strings.TrimSpace(override)
+	if trimmed == "" {
+		return false
+	}
+	if strings.ContainsAny(trimmed, " \r\n\t") {
+		return false
+	}
+
+	requestHost := strings.TrimSpace(parsedURL.Host)
+	requestHostname := strings.TrimSpace(parsedURL.Hostname())
+	if requestHost == "" {
+		return false
+	}
+	if strings.EqualFold(trimmed, requestHost) {
+		return true
+	}
+	if strings.EqualFold(trimmed, requestHostname) {
+		return true
+	}
+	if len(trimmed) > 2 && trimmed[0] == '[' && trimmed[len(trimmed)-1] == ']' {
+		return false
+	}
+	return false
+}
+
 func validateAPICallURL(parsedURL *url.URL) error {
 	if parsedURL == nil {
 		return fmt.Errorf("invalid url")
@@ -306,17 +339,53 @@ func validateAPICallURL(parsedURL *url.URL) error {
 	if scheme != "http" && scheme != "https" {
 		return fmt.Errorf("unsupported url scheme")
 	}
+	if parsedURL.User != nil {
+		return fmt.Errorf("target host is not allowed")
+	}
 	host := strings.TrimSpace(parsedURL.Hostname())
 	if host == "" {
 		return fmt.Errorf("invalid url host")
-	}
-	if parsedURL.User != nil {
-		return fmt.Errorf("target user info is not allowed")
 	}
 	if strings.EqualFold(host, "localhost") {
 		return fmt.Errorf("target host is not allowed")
 	}
 	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("target host is not allowed")
+		}
+	}
+	return nil
+}
+
+func sanitizeAPICallURL(raw string) (string, *url.URL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil, fmt.Errorf("missing url")
+	}
+	parsedURL, errParseURL := url.Parse(trimmed)
+	if errParseURL != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", nil, fmt.Errorf("invalid url")
+	}
+	if errValidateURL := validateAPICallURL(parsedURL); errValidateURL != nil {
+		return "", nil, errValidateURL
+	}
+	parsedURL.Fragment = ""
+	return parsedURL.String(), parsedURL, nil
+}
+
+func validateResolvedHostIPs(host string) error {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return fmt.Errorf("invalid url host")
+	}
+	resolved, errLookup := net.LookupIP(trimmed)
+	if errLookup != nil {
+		return fmt.Errorf("target host resolution failed")
+	}
+	for _, ip := range resolved {
+		if ip == nil {
+			continue
+		}
 		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 			return fmt.Errorf("target host is not allowed")
 		}
@@ -728,10 +797,12 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 }
 
 func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+	hasAuthProxy := false
 	var proxyCandidates []string
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {
 			proxyCandidates = append(proxyCandidates, proxyStr)
+			hasAuthProxy = true
 		}
 	}
 	if h != nil && h.cfg != nil {
@@ -741,9 +812,14 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 	}
 
 	for _, proxyStr := range proxyCandidates {
-		if transport := buildProxyTransport(proxyStr); transport != nil {
+		transport, errBuild := buildProxyTransportWithError(proxyStr)
+		if transport != nil {
 			return transport
 		}
+		if hasAuthProxy {
+			return &transportFailureRoundTripper{err: fmt.Errorf("authentication proxy misconfigured: %v", errBuild)}
+		}
+		log.Debugf("failed to setup API call proxy from URL: %s, trying next candidate", proxyStr)
 	}
 
 	transport, ok := http.DefaultTransport.(*http.Transport)
@@ -755,20 +831,20 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 	return clone
 }
 
-func buildProxyTransport(proxyStr string) *http.Transport {
+func buildProxyTransportWithError(proxyStr string) (*http.Transport, error) {
 	proxyStr = strings.TrimSpace(proxyStr)
 	if proxyStr == "" {
-		return nil
+		return nil, fmt.Errorf("proxy URL is empty")
 	}
 
 	proxyURL, errParse := url.Parse(proxyStr)
 	if errParse != nil {
 		log.WithError(errParse).Debug("parse proxy URL failed")
-		return nil
+		return nil, fmt.Errorf("parse proxy URL failed: %w", errParse)
 	}
 	if proxyURL.Scheme == "" || proxyURL.Host == "" {
 		log.Debug("proxy URL missing scheme/host")
-		return nil
+		return nil, fmt.Errorf("missing proxy scheme or host: %s", proxyStr)
 	}
 
 	if proxyURL.Scheme == "socks5" {
@@ -781,22 +857,30 @@ func buildProxyTransport(proxyStr string) *http.Transport {
 		dialer, errSOCKS5 := proxy.SOCKS5("tcp", proxyURL.Host, proxyAuth, proxy.Direct)
 		if errSOCKS5 != nil {
 			log.WithError(errSOCKS5).Debug("create SOCKS5 dialer failed")
-			return nil
+			return nil, fmt.Errorf("create SOCKS5 dialer failed: %w", errSOCKS5)
 		}
 		return &http.Transport{
 			Proxy: nil,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return dialer.Dial(network, addr)
 			},
-		}
+		}, nil
 	}
 
 	if proxyURL.Scheme == "http" || proxyURL.Scheme == "https" {
-		return &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+		return &http.Transport{Proxy: http.ProxyURL(proxyURL)}, nil
 	}
 
 	log.Debugf("unsupported proxy scheme: %s", proxyURL.Scheme)
-	return nil
+	return nil, fmt.Errorf("unsupported proxy scheme: %s", proxyURL.Scheme)
+}
+
+type transportFailureRoundTripper struct {
+	err error
+}
+
+func (t *transportFailureRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
 }
 
 // headerContainsValue checks whether a header map contains a target value (case-insensitive key and value).
@@ -1221,6 +1305,16 @@ func (h *Handler) enrichCopilotTokenResponse(ctx context.Context, response apiCa
 		log.WithError(errQuotaURL).Debug("enrichCopilotTokenResponse: rejected token URL for quota request")
 		return response
 	}
+	parsedQuotaURL, errParseQuotaURL := url.Parse(quotaURL)
+	if errParseQuotaURL != nil {
+		return response
+	}
+	if errValidate := validateAPICallURL(parsedQuotaURL); errValidate != nil {
+		return response
+	}
+	if errResolve := validateResolvedHostIPs(parsedQuotaURL.Hostname()); errResolve != nil {
+		return response
+	}
 
 	req, errNewRequest := http.NewRequestWithContext(ctx, http.MethodGet, quotaURL, nil)
 	if errNewRequest != nil {
@@ -1367,26 +1461,12 @@ func copilotQuotaURLFromTokenURL(originalURL string) (string, error) {
 	if errParse != nil {
 		return "", errParse
 	}
-	if parsedURL == nil || !parsedURL.IsAbs() {
-		return "", fmt.Errorf("invalid token url")
-	}
 	if parsedURL.User != nil {
-		return "", fmt.Errorf("token url must not include user info")
+		return "", fmt.Errorf("unsupported host %q", parsedURL.Hostname())
 	}
 	host := strings.ToLower(parsedURL.Hostname())
-	if host == "" {
-		return "", fmt.Errorf("token url host is required")
-	}
 	if parsedURL.Scheme != "https" {
 		return "", fmt.Errorf("unsupported scheme %q", parsedURL.Scheme)
-	}
-	if strings.EqualFold(host, "localhost") {
-		return "", fmt.Errorf("token url host is not allowed")
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-			return "", fmt.Errorf("token url host is not allowed")
-		}
 	}
 	switch host {
 	case "api.github.com", "api.githubcopilot.com":

--- a/pkg/llmproxy/auth/kiro/token.go
+++ b/pkg/llmproxy/auth/kiro/token.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/misc"
 )
 
 // KiroTokenStorage holds the persistent token data for Kiro authentication.
@@ -66,20 +68,109 @@ func cleanTokenPath(path, scope string) (string, error) {
 	if trimmed == "" {
 		return "", fmt.Errorf("%s: auth file path is empty", scope)
 	}
-	clean := filepath.Clean(filepath.FromSlash(trimmed))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+	normalizedInput := filepath.FromSlash(trimmed)
+	safe, err := misc.ResolveSafeFilePath(normalizedInput)
+	if err != nil {
 		return "", fmt.Errorf("%s: auth file path is invalid", scope)
 	}
-	abs, err := filepath.Abs(clean)
+
+	baseDir, absPath, err := normalizePathWithinBase(safe)
 	if err != nil {
-		return "", fmt.Errorf("%s: resolve auth file path: %w", scope, err)
+		return "", fmt.Errorf("%s: auth file path is invalid", scope)
+	}
+	if err := denySymlinkPath(baseDir, absPath); err != nil {
+		return "", fmt.Errorf("%s: auth file path is invalid", scope)
+	}
+	return absPath, nil
+}
+
+func normalizePathWithinBase(path string) (string, string, error) {
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." || cleanPath == ".." {
+		return "", "", fmt.Errorf("path is invalid")
+	}
+
+	var (
+		baseDir string
+		absPath string
+		err     error
+	)
+
+	if filepath.IsAbs(cleanPath) {
+		absPath = filepath.Clean(cleanPath)
+		baseDir = filepath.Clean(filepath.Dir(absPath))
+	} else {
+		baseDir, err = os.Getwd()
+		if err != nil {
+			return "", "", fmt.Errorf("resolve working directory: %w", err)
+		}
+		baseDir, err = filepath.Abs(baseDir)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve base directory: %w", err)
+		}
+		absPath = filepath.Clean(filepath.Join(baseDir, cleanPath))
+	}
+
+	if !pathWithinBase(baseDir, absPath) {
+		return "", "", fmt.Errorf("path escapes base directory")
+	}
+	return filepath.Clean(baseDir), filepath.Clean(absPath), nil
+}
+
+func pathWithinBase(baseDir, path string) bool {
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func denySymlinkPath(baseDir, targetPath string) error {
+	if !pathWithinBase(baseDir, targetPath) {
+		return fmt.Errorf("path escapes base directory")
+	}
+	rel, err := filepath.Rel(baseDir, targetPath)
+	if err != nil {
+		return fmt.Errorf("resolve relative path: %w", err)
+	}
+	if rel == "." {
+		return nil
+	}
+	current := filepath.Clean(baseDir)
+	for _, component := range strings.Split(rel, string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, errStat := os.Lstat(current)
+		if errStat != nil {
+			if os.IsNotExist(errStat) {
+				return nil
+			}
+			return fmt.Errorf("stat path: %w", errStat)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink is not allowed in auth file path")
+		}
+	}
+	return nil
+}
+
+func cleanAuthPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve auth file path: %w", err)
 	}
 	return filepath.Clean(abs), nil
 }
 
 // LoadFromFile loads token storage from the specified file path.
 func LoadFromFile(authFilePath string) (*KiroTokenStorage, error) {
-	data, err := os.ReadFile(authFilePath)
+	cleanPath, err := cleanTokenPath(authFilePath, "kiro token")
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read token file: %w", err)
 	}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -1,9 +1,10 @@
 package auth
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -132,8 +133,10 @@ func stableAuthIndex(seed string) string {
 	if seed == "" {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(seed))
-	return hex.EncodeToString(sum[:])
+	mac := hmac.New(sha256.New, []byte("cliproxy-auth-index-v1"))
+	_, _ = mac.Write([]byte(seed))
+	sum := mac.Sum(nil)
+	return fmt.Sprintf("%x", sum[:])
 }
 
 // EnsureIndex returns a stable index derived from the auth file name or API key.


### PR DESCRIPTION
Rebased version of PR #239 with resolved merge conflicts.

## Summary
- SSRF protection via validateResolvedHostIPs
- Path sanitization via cleanTokenPath
- HMAC-based hashing for sensitive IDs
- Request/response body redaction in logs

## Tests
- pkg/llmproxy/api/middleware: PASS

Closes #239