### PR TITLE
feat: add management API handler extensions

### DIFF
--- a/pkg/llmproxy/api/handlers/management/alerts.go
+++ b/pkg/llmproxy/api/handlers/management/alerts.go
@@ -1,0 +1,409 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Alert represents a system alert
+type Alert struct {
+	ID          string     `json:"id"`
+	Type        AlertType  `json:"type"` // error_rate, latency, cost, uptime, provider
+	Severity    Severity   `json:"severity"` // critical, warning, info
+	Status      AlertStatus `json:"status"` // firing, resolved
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	MetricName  string     `json:"metric_name,omitempty"`
+	Threshold   float64    `json:"threshold,omitempty"`
+	CurrentValue float64  `json:"current_value,omitempty"`
+	Provider    string     `json:"provider,omitempty"`
+	ModelID     string     `json:"model_id,omitempty"`
+	StartedAt   time.Time  `json:"started_at"`
+	ResolvedAt  *time.Time `json:"resolved_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// AlertType represents the type of alert
+type AlertType string
+
+const (
+	AlertTypeErrorRate  AlertType = "error_rate"
+	AlertTypeLatency   AlertType = "latency"
+	AlertTypeCost      AlertType = "cost"
+	AlertTypeUptime    AlertType = "uptime"
+	AlertTypeProvider  AlertType = "provider"
+	AlertTypeQuota     AlertType = "quota"
+	AlertTypeInfo     AlertType = "info"
+)
+
+// Severity represents alert severity
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarning  Severity = "warning"
+	SeverityInfo     Severity = "info"
+)
+
+// AlertStatus represents alert status
+type AlertStatus string
+
+const (
+	AlertStatusFiring  AlertStatus = "firing"
+	AlertStatusResolved AlertStatus = "resolved"
+)
+
+// AlertRule defines conditions for triggering alerts
+type AlertRule struct {
+	Name        string      `json:"name"`
+	Type        AlertType   `json:"type"`
+	Severity    Severity    `json:"severity"`
+	Threshold   float64     `json:"threshold"`
+	Duration    time.Duration `json:"duration"` // How long condition must be true
+	Cooldown    time.Duration `json:"cooldown"` // Time before next alert
+	Enabled     bool        `json:"enabled"`
+	Notify      []string    `json:"notify"` // notification channels
+}
+
+// AlertManager manages alerts and rules
+type AlertManager struct {
+	mu           sync.RWMutex
+	rules        map[string]*AlertRule
+	activeAlerts map[string]*Alert
+	alertHistory  []Alert
+	maxHistory    int
+	notifiers    []AlertNotifier
+}
+
+// AlertNotifier defines an interface for alert notifications
+type AlertNotifier interface {
+	Send(ctx context.Context, alert *Alert) error
+}
+
+// NewAlertManager creates a new AlertManager
+func NewAlertManager() *AlertManager {
+	return &AlertManager{
+		rules:        make(map[string]*AlertRule),
+		activeAlerts: make(map[string]*Alert),
+		alertHistory:  make([]Alert, 0),
+		maxHistory:    1000,
+		notifiers:    make([]AlertNotifier, 0),
+	}
+}
+
+// AddRule adds an alert rule
+func (m *AlertManager) AddRule(rule *AlertRule) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rules[rule.Name] = rule
+}
+
+// RemoveRule removes an alert rule
+func (m *AlertManager) RemoveRule(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rules, name)
+}
+
+// GetRules returns all alert rules
+func (m *AlertManager) GetRules() []*AlertRule {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	rules := make([]*AlertRule, 0, len(m.rules))
+	for _, r := range m.rules {
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+// AddNotifier adds a notification channel
+func (m *AlertManager) AddNotifier(notifier AlertNotifier) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.notifiers = append(m.notifiers, notifier)
+}
+
+// EvaluateMetrics evaluates current metrics against rules
+func (m *AlertManager) EvaluateMetrics(ctx context.Context, metrics map[string]float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, rule := range m.rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		value, exists := metrics[string(rule.Type)]
+		if !exists {
+			continue
+		}
+
+		alertKey := fmt.Sprintf("%s:%s", rule.Name, rule.Type)
+		
+		switch rule.Type {
+		case AlertTypeErrorRate, AlertTypeLatency:
+			if value > rule.Threshold {
+				m.triggerOrUpdateAlert(ctx, alertKey, rule, value)
+			} else {
+				m.resolveAlert(ctx, alertKey)
+			}
+		case AlertTypeCost:
+			if value > rule.Threshold {
+				m.triggerOrUpdateAlert(ctx, alertKey, rule, value)
+			}
+		}
+	}
+}
+
+// triggerOrUpdateAlert triggers or updates an alert
+func (m *AlertManager) triggerOrUpdateAlert(ctx context.Context, key string, rule *AlertRule, value float64) {
+	if existing, ok := m.activeAlerts[key]; ok {
+		// Update existing alert
+		existing.CurrentValue = value
+		return
+	}
+
+	// Create new alert
+	alert := &Alert{
+		ID:           fmt.Sprintf("alert-%d", time.Now().Unix()),
+		Type:         rule.Type,
+		Severity:     rule.Severity,
+		Status:       AlertStatusFiring,
+		Title:        fmt.Sprintf("%s %s", rule.Type, getSeverityText(rule.Severity)),
+		Description:  fmt.Sprintf("%s exceeded threshold: %.2f > %.2f", rule.Type, value, rule.Threshold),
+		MetricName:   string(rule.Type),
+		Threshold:    rule.Threshold,
+		CurrentValue: value,
+		StartedAt:    time.Now(),
+		CreatedAt:    time.Now(),
+	}
+
+	m.activeAlerts[key] = alert
+	m.alertHistory = append(m.alertHistory, *alert)
+
+	// Send notifications
+	m.sendNotifications(ctx, alert)
+}
+
+// resolveAlert resolves an active alert
+func (m *AlertManager) resolveAlert(ctx context.Context, key string) {
+	alert, ok := m.activeAlerts[key]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	alert.Status = AlertStatusResolved
+	alert.ResolvedAt = &now
+
+	delete(m.activeAlerts, key)
+	m.alertHistory = append(m.alertHistory, *alert)
+}
+
+// sendNotifications sends alert to all notifiers
+func (m *AlertManager) sendNotifications(ctx context.Context, alert *Alert) {
+	for _, notifier := range m.notifiers {
+		if err := notifier.Send(ctx, alert); err != nil {
+			// Log error but continue
+			fmt.Printf("Failed to send notification: %v\n", err)
+		}
+	}
+}
+
+// GetActiveAlerts returns all active alerts
+func (m *AlertManager) GetActiveAlerts() []Alert {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	alerts := make([]Alert, 0, len(m.activeAlerts))
+	for _, a := range m.activeAlerts {
+		alerts = append(alerts, *a)
+	}
+	return alerts
+}
+
+// GetAlertHistory returns alert history
+func (m *AlertManager) GetAlertHistory(limit int) []Alert {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if limit <= 0 || limit > len(m.alertHistory) {
+		limit = len(m.alertHistory)
+	}
+	
+	result := make([]Alert, limit)
+	copy(result, m.alertHistory[len(m.alertHistory)-limit:])
+	return result
+}
+
+// getSeverityText returns text description of severity
+func getSeverityText(s Severity) string {
+	switch s {
+	case SeverityCritical:
+		return "critical alert"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "info"
+	default:
+		return "alert"
+	}
+}
+
+// CommonAlertRules returns typical alert rules
+func CommonAlertRules() []*AlertRule {
+	return []*AlertRule{
+		{
+			Name:     "high-error-rate",
+			Type:     AlertTypeErrorRate,
+			Severity: SeverityCritical,
+			Threshold: 5.0, // 5% error rate
+			Duration: 5 * time.Minute,
+			Cooldown: 15 * time.Minute,
+			Enabled:  true,
+			Notify:   []string{"slack", "email"},
+		},
+		{
+			Name:     "high-latency",
+			Type:     AlertTypeLatency,
+			Severity: SeverityWarning,
+			Threshold: 10000, // 10 seconds
+			Duration: 10 * time.Minute,
+			Cooldown: 30 * time.Minute,
+			Enabled:  true,
+			Notify:   []string{"slack"},
+		},
+		{
+			Name:     "high-cost",
+			Type:     AlertTypeCost,
+			Severity: SeverityWarning,
+			Threshold: 1000.0, // $1000
+			Duration: 1 * time.Hour,
+			Cooldown: 1 * time.Hour,
+			Enabled:  true,
+			Notify:   []string{"email"},
+		},
+		{
+			Name:     "provider-outage",
+			Type:     AlertTypeProvider,
+			Severity: SeverityCritical,
+			Threshold: 90.0, // 90% uptime threshold
+			Duration: 5 * time.Minute,
+			Cooldown: 10 * time.Minute,
+			Enabled:  true,
+			Notify:   []string{"slack", "email", "pagerduty"},
+		},
+	}
+}
+
+// AlertHandler handles alert API endpoints
+type AlertHandler struct {
+	manager *AlertManager
+}
+
+// NewAlertHandler creates a new AlertHandler
+func NewAlertHandler() *AlertHandler {
+	m := NewAlertManager()
+	// Add default rules
+	for _, rule := range CommonAlertRules() {
+		m.AddRule(rule)
+	}
+	return &AlertHandler{manager: m}
+}
+
+// GETAlerts handles GET /v1/alerts
+func (h *AlertHandler) GETAlerts(c *gin.Context) {
+	status := c.Query("status")
+	alertType := c.Query("type")
+
+	alerts := h.manager.GetActiveAlerts()
+
+	// Filter
+	if status != "" {
+		var filtered []Alert
+		for _, a := range alerts {
+			if string(a.Status) == status {
+				filtered = append(filtered, a)
+			}
+		}
+		alerts = filtered
+	}
+
+	if alertType != "" {
+		var filtered []Alert
+		for _, a := range alerts {
+			if string(a.Type) == alertType {
+				filtered = append(filtered, a)
+			}
+		}
+		alerts = filtered
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"count":  len(alerts),
+		"alerts": alerts,
+	})
+}
+
+// GETAlertHistory handles GET /v1/alerts/history
+func (h *AlertHandler) GETAlertHistory(c *gin.Context) {
+	limit := 50
+	fmt.Sscanf(c.DefaultQuery("limit", "50"), "%d", &limit)
+
+	history := h.manager.GetAlertHistory(limit)
+
+	c.JSON(http.StatusOK, gin.H{
+		"count":  len(history),
+		"alerts": history,
+	})
+}
+
+// GETAlertRules handles GET /v1/alerts/rules
+func (h *AlertHandler) GETAlertRules(c *gin.Context) {
+	rules := h.manager.GetRules()
+	c.JSON(http.StatusOK, gin.H{"rules": rules})
+}
+
+// POSTAlertRule handles POST /v1/alerts/rules
+func (h *AlertHandler) POSTAlertRule(c *gin.Context) {
+	var rule AlertRule
+	if err := c.ShouldBindJSON(&rule); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	h.manager.AddRule(&rule)
+	c.JSON(http.StatusCreated, gin.H{"message": "rule created", "rule": rule})
+}
+
+// DELETEAlertRule handles DELETE /v1/alerts/rules/:name
+func (h *AlertHandler) DELETEAlertRule(c *gin.Context) {
+	name := c.Param("name")
+	h.manager.RemoveRule(name)
+	c.JSON(http.StatusOK, gin.H{"message": "rule deleted"})
+}
+
+// POSTTestAlert handles POST /v1/alerts/test (for testing notifications)
+func (h *AlertHandler) POSTTestAlert(c *gin.Context) {
+	alert := &Alert{
+		ID:          "test-alert",
+		Type:        AlertTypeInfo,
+		Severity:    SeverityInfo,
+		Status:      AlertStatusFiring,
+		Title:       "Test Alert",
+		Description: "This is a test alert",
+		StartedAt:   time.Now(),
+		CreatedAt:   time.Now(),
+	}
+
+	ctx := c.Request.Context()
+	h.manager.sendNotifications(ctx, alert)
+
+	c.JSON(http.StatusOK, gin.H{"message": "test alert sent"})
+}

--- a/pkg/llmproxy/api/handlers/management/provider_status.go
+++ b/pkg/llmproxy/api/handlers/management/provider_status.go
@@ -1,0 +1,205 @@
+package management
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ProviderStatusRequest is the request for provider status
+type ProviderStatusRequest struct {
+	Provider string `uri:"provider" binding:"required"`
+}
+
+// ProviderStatusResponse is the JSON response for provider status
+type ProviderStatusResponse struct {
+	Provider      string           `json:"provider"`
+	UpdatedAt     time.Time        `json:"updated_at"`
+	Status        string           `json:"status"` // operational, degraded, outage
+	Uptime24h     float64         `json:"uptime_24h"`
+	Uptime7d      float64         `json:"uptime_7d"`
+	AvgLatencyMs  float64         `json:"avg_latency_ms"`
+	TotalRequests int64           `json:"total_requests"`
+	ErrorRate     float64          `json:"error_rate"`
+	Regions       []RegionStatus   `json:"regions"`
+	Models        []ProviderModel  `json:"models"`
+	Incidents     []Incident       `json:"incidents,omitempty"`
+}
+
+// RegionStatus contains status for a specific region
+type RegionStatus struct {
+	Region        string  `json:"region"`
+	Status        string  `json:"status"` // operational, degraded, outage
+	LatencyMs     float64 `json:"latency_ms"`
+	ThroughputTPS float64 `json:"throughput_tps"`
+	UptimePercent float64 `json:"uptime_percent"`
+}
+
+// ProviderModel contains model availability for a provider
+type ProviderModel struct {
+	ModelID         string  `json:"model_id"`
+	Available       bool    `json:"available"`
+	LatencyMs       int     `json:"latency_ms"`
+	ThroughputTPS   float64 `json:"throughput_tps"`
+	QueueDepth      int     `json:"queue_depth,omitempty"`
+	MaxConcurrency int     `json:"max_concurrency,omitempty"`
+}
+
+// Incident represents an ongoing or past incident
+type Incident struct {
+	ID          string     `json:"id"`
+	Type        string     `json:"type"` // outage, degradation, maintenance
+	Severity    string     `json:"severity"` // critical, major, minor
+	Status      string     `json:"status"` // ongoing, resolved
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	StartedAt   time.Time `json:"started_at"`
+	ResolvedAt  *time.Time `json:"resolved_at,omitempty"`
+	Affected    []string  `json:"affected,omitempty"`
+}
+
+// ProviderStatusHandler handles provider status endpoints
+type ProviderStatusHandler struct{}
+
+// NewProviderStatusHandler returns a new ProviderStatusHandler
+func NewProviderStatusHandler() *ProviderStatusHandler {
+	return &ProviderStatusHandler{}
+}
+
+// GETProviderStatus handles GET /v1/providers/:provider/status
+func (h *ProviderStatusHandler) GETProviderStatus(c *gin.Context) {
+	var req ProviderStatusRequest
+	if err := c.ShouldBindUri(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	status := h.getMockProviderStatus(req.Provider)
+	if status == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}
+
+// getMockProviderStatus returns mock provider status
+func (h *ProviderStatusHandler) getMockProviderStatus(provider string) *ProviderStatusResponse {
+	providerData := map[string]*ProviderStatusResponse{
+		"google": {
+			Provider:      "google",
+			UpdatedAt:     time.Now(),
+			Status:        "operational",
+			Uptime24h:     99.2,
+			Uptime7d:      98.9,
+			AvgLatencyMs:  1250,
+			TotalRequests:  50000000,
+			ErrorRate:      0.8,
+			Regions: []RegionStatus{
+				{Region: "US", Status: "operational", LatencyMs: 800, ThroughputTPS: 150, UptimePercent: 99.5},
+				{Region: "EU", Status: "operational", LatencyMs: 1500, ThroughputTPS: 100, UptimePercent: 99.1},
+				{Region: "ASIA", Status: "degraded", LatencyMs: 2200, ThroughputTPS: 60, UptimePercent: 96.5},
+			},
+			Models: []ProviderModel{
+				{ModelID: "gemini-3.1-pro", Available: true, LatencyMs: 3000, ThroughputTPS: 72, MaxConcurrency: 50},
+				{ModelID: "gemini-3-flash-preview", Available: true, LatencyMs: 600, ThroughputTPS: 200, MaxConcurrency: 100},
+				{ModelID: "gemini-2.5-flash", Available: true, LatencyMs: 500, ThroughputTPS: 250, MaxConcurrency: 100},
+			},
+		},
+		"anthropic": {
+			Provider:      "anthropic",
+			UpdatedAt:     time.Now(),
+			Status:        "operational",
+			Uptime24h:     99.5,
+			Uptime7d:      99.3,
+			AvgLatencyMs:  1800,
+			TotalRequests: 35000000,
+			ErrorRate:      0.5,
+			Regions: []RegionStatus{
+				{Region: "US", Status: "operational", LatencyMs: 1500, ThroughputTPS: 80, UptimePercent: 99.5},
+				{Region: "EU", Status: "operational", LatencyMs: 2200, ThroughputTPS: 50, UptimePercent: 99.2},
+			},
+			Models: []ProviderModel{
+				{ModelID: "claude-opus-4.6", Available: true, LatencyMs: 4000, ThroughputTPS: 45, MaxConcurrency: 30},
+				{ModelID: "claude-sonnet-4.6", Available: true, LatencyMs: 2000, ThroughputTPS: 80, MaxConcurrency: 50},
+				{ModelID: "claude-haiku-4.5", Available: true, LatencyMs: 800, ThroughputTPS: 150, MaxConcurrency: 100},
+			},
+		},
+		"openai": {
+			Provider:      "openai",
+			UpdatedAt:     time.Now(),
+			Status:        "operational",
+			Uptime24h:     98.8,
+			Uptime7d:      98.5,
+			AvgLatencyMs:  2000,
+			TotalRequests:  42000000,
+			ErrorRate:      1.2,
+			Regions: []RegionStatus{
+				{Region: "US", Status: "operational", LatencyMs: 1800, ThroughputTPS: 100, UptimePercent: 99.0},
+				{Region: "EU", Status: "degraded", LatencyMs: 2800, ThroughputTPS: 60, UptimePercent: 97.0},
+			},
+			Models: []ProviderModel{
+				{ModelID: "gpt-5.2", Available: true, LatencyMs: 3500, ThroughputTPS: 60, MaxConcurrency: 40},
+				{ModelID: "gpt-4o", Available: true, LatencyMs: 2000, ThroughputTPS: 80, MaxConcurrency: 50},
+			},
+		},
+	}
+
+	if data, ok := providerData[provider]; ok {
+		return data
+	}
+
+	return nil
+}
+
+// GETAllProviderStatuses handles GET /v1/providers/status
+func (h *ProviderStatusHandler) GETAllProviderStatuses(c *gin.Context) {
+	providers := []string{"google", "anthropic", "openai", "deepseek", "minimax", "moonshotai", "x-ai", "z-ai"}
+	
+	var statuses []ProviderStatusResponse
+	for _, p := range providers {
+		if status := h.getMockProviderStatus(p); status != nil {
+			statuses = append(statuses, *status)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"updated_at": time.Now(),
+		"count":      len(statuses),
+		"providers":  statuses,
+	})
+}
+
+// GETProviderIncidents handles GET /v1/providers/:provider/incidents
+func (h *ProviderStatusHandler) GETProviderIncidents(c *gin.Context) {
+	var req ProviderStatusRequest
+	if err := c.ShouldBindUri(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Mock incidents
+	incidents := []Incident{
+		{
+			ID:          "inc-001",
+			Type:        "degradation",
+			Severity:    "minor",
+			Status:      "resolved",
+			Title:       "Elevated latency in Asia Pacific region",
+			Description: "Users in APAC experienced elevated latency due to network congestion",
+			StartedAt:   time.Now().Add(-24 * time.Hour),
+			ResolvedAt:  timePtr(time.Now().Add(-12 * time.Hour)),
+			Affected:    []string{"gemini-2.5-flash", "gemini-3-flash-preview"},
+		},
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"provider":  req.Provider,
+		"incidents": incidents,
+	})
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/pkg/llmproxy/api/handlers/management/rankings.go
+++ b/pkg/llmproxy/api/handlers/management/rankings.go
@@ -1,0 +1,254 @@
+package management
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RankingCategory represents a category for model rankings
+type RankingCategory string
+
+const (
+	// RankingByUsage ranks by token usage
+	RankingByUsage RankingCategory = "usage"
+	// RankingByQuality ranks by quality score
+	RankingByQuality RankingCategory = "quality"
+	// RankingBySpeed ranks by speed/latency
+	RankingBySpeed RankingCategory = "speed"
+	// RankingByCost ranks by cost efficiency
+	RankingByCost RankingCategory = "cost"
+	// RankingByPopularity ranks by popularity
+	RankingByPopularity RankingCategory = "popularity"
+)
+
+// RankingsRequest is the JSON body for GET /v1/rankings
+type RankingsRequest struct {
+	// Category is the ranking category: usage, quality, speed, cost, popularity
+	Category string `form:"category"`
+	// Limit is the number of results to return
+	Limit int `form:"limit"`
+	// Provider filters to specific provider
+	Provider string `form:"provider"`
+	// TimeRange is the time range: week, month, all
+	TimeRange string `form:"timeRange"`
+}
+
+// RankingsResponse is the JSON response for GET /v1/rankings
+type RankingsResponse struct {
+	Category   string        `json:"category"`
+	TimeRange  string        `json:"timeRange"`
+	UpdatedAt  time.Time     `json:"updated_at"`
+	TotalCount int          `json:"total_count"`
+	Rankings   []ModelRank  `json:"rankings"`
+}
+
+// ModelRank represents a model's ranking entry
+type ModelRank struct {
+	Rank              int     `json:"rank"`
+	ModelID           string  `json:"model_id"`
+	Provider          string  `json:"provider"`
+	QualityScore      float64 `json:"quality_score"`
+	EstimatedCost     float64 `json:"estimated_cost"`
+	LatencyMs         int     `json:"latency_ms"`
+	WeeklyTokens      int64   `json:"weekly_tokens"`
+	MarketSharePercent float64 `json:"market_share_percent"`
+	Category          string  `json:"category,omitempty"`
+}
+
+// RankingsHandler handles the /v1/rankings endpoint
+type RankingsHandler struct {
+	// This would connect to actual usage data in production
+}
+
+// NewRankingsHandler returns a new RankingsHandler
+func NewRankingsHandler() *RankingsHandler {
+	return &RankingsHandler{}
+}
+
+// GETRankings handles GET /v1/rankings
+func (h *RankingsHandler) GETRankings(c *gin.Context) {
+	var req RankingsRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Set defaults
+	if req.Category == "" {
+		req.Category = string(RankingByUsage)
+	}
+	if req.Limit == 0 || req.Limit > 100 {
+		req.Limit = 20
+	}
+	if req.TimeRange == "" {
+		req.TimeRange = "week"
+	}
+
+	// Generate rankings based on category (in production, this would come from actual metrics)
+	rankings := h.generateRankings(req)
+
+	c.JSON(http.StatusOK, RankingsResponse{
+		Category:   req.Category,
+		TimeRange:  req.TimeRange,
+		UpdatedAt:  time.Now(),
+		TotalCount: len(rankings),
+		Rankings:   rankings[:min(len(rankings), req.Limit)],
+	})
+}
+
+// generateRankings generates mock rankings based on category
+// In production, this would fetch from actual metrics storage
+func (h *RankingsHandler) generateRankings(req RankingsRequest) []ModelRank {
+	// This would be replaced with actual data from metrics storage
+	mockModels := []struct {
+		ModelID    string
+		Provider   string
+		Quality    float64
+		Cost       float64
+		Latency    int
+		WeeklyTokens int64
+	}{
+		{"claude-opus-4.6", "anthropic", 0.95, 0.015, 4000, 651000000000},
+		{"claude-sonnet-4.6", "anthropic", 0.88, 0.003, 2000, 520000000000},
+		{"gemini-3.1-pro", "google", 0.90, 0.007, 3000, 100000000000},
+		{"gemini-3-flash-preview", "google", 0.78, 0.00015, 600, 887000000000},
+		{"gpt-5.2", "openai", 0.92, 0.020, 3500, 300000000000},
+		{"deepseek-v3.2", "deepseek", 0.80, 0.0005, 1000, 762000000000},
+		{"glm-5", "z-ai", 0.78, 0.001, 1500, 769000000000},
+		{"minimax-m2.5", "minimax", 0.75, 0.001, 1200, 2290000000000},
+		{"kimi-k2.5", "moonshotai", 0.82, 0.001, 1100, 967000000000},
+		{"grok-4.1-fast", "x-ai", 0.76, 0.001, 800, 692000000000},
+		{"gemini-2.5-flash", "google", 0.76, 0.0001, 500, 429000000000},
+		{"claude-haiku-4.5", "anthropic", 0.75, 0.00025, 800, 100000000000},
+	}
+
+	// Filter by provider if specified
+	var filtered []struct {
+		ModelID    string
+		Provider   string
+		Quality    float64
+		Cost       float64
+		Latency    int
+		WeeklyTokens int64
+	}
+	
+	if req.Provider != "" {
+		for _, m := range mockModels {
+			if m.Provider == req.Provider {
+				filtered = append(filtered, m)
+			}
+		}
+	} else {
+		filtered = mockModels
+	}
+
+	// Sort based on category
+	switch RankingCategory(req.Category) {
+	case RankingByUsage:
+		sort.Slice(filtered, func(i, j int) bool {
+			return filtered[i].WeeklyTokens > filtered[j].WeeklyTokens
+		})
+	case RankingByQuality:
+		sort.Slice(filtered, func(i, j int) bool {
+			return filtered[i].Quality > filtered[j].Quality
+		})
+	case RankingBySpeed:
+		sort.Slice(filtered, func(i, j int) bool {
+			return filtered[i].Latency < filtered[j].Latency
+		})
+	case RankingByCost:
+		sort.Slice(filtered, func(i, j int) bool {
+			return filtered[i].Cost < filtered[j].Cost
+		})
+	default:
+		sort.Slice(filtered, func(i, j int) bool {
+			return filtered[i].WeeklyTokens > filtered[j].WeeklyTokens
+		})
+	}
+
+	// Calculate total tokens for market share
+	var totalTokens int64
+	for _, m := range filtered {
+		totalTokens += m.WeeklyTokens
+	}
+
+	// Build rankings
+	rankings := make([]ModelRank, len(filtered))
+	for i, m := range filtered {
+		marketShare := 0.0
+		if totalTokens > 0 {
+			marketShare = float64(m.WeeklyTokens) / float64(totalTokens) * 100
+		}
+		rankings[i] = ModelRank{
+			Rank:               i + 1,
+			ModelID:            m.ModelID,
+			Provider:           m.Provider,
+			QualityScore:       m.Quality,
+			EstimatedCost:      m.Cost,
+			LatencyMs:          m.Latency,
+			WeeklyTokens:       m.WeeklyTokens,
+			MarketSharePercent: marketShare,
+		}
+	}
+
+	return rankings
+}
+
+// GETProviderRankings handles GET /v1/rankings/providers
+func (h *RankingsHandler) GETProviderRankings(c *gin.Context) {
+	// Mock provider rankings
+	providerRankings := []gin.H{
+		{"rank": 1, "provider": "google", "weekly_tokens": 730000000000, "market_share": 19.2, "model_count": 15},
+		{"rank": 2, "provider": "anthropic", "weekly_tokens": 559000000000, "market_share": 14.7, "model_count": 8},
+		{"rank": 3, "provider": "minimax", "weekly_tokens": 539000000000, "market_share": 14.2, "model_count": 5},
+		{"rank": 4, "provider": "openai", "weekly_tokens": 351000000000, "market_share": 9.2, "model_count": 12},
+		{"rank": 5, "provider": "z-ai", "weekly_tokens": 327000000000, "market_share": 8.6, "model_count": 6},
+		{"rank": 6, "provider": "deepseek", "weekly_tokens": 304000000000, "market_share": 8.0, "model_count": 4},
+		{"rank": 7, "provider": "x-ai", "weekly_tokens": 231000000000, "market_share": 6.1, "model_count": 3},
+		{"rank": 8, "provider": "moonshotai", "weekly_tokens": 184000000000, "market_share": 4.8, "model_count": 3},
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"updated_at": time.Now(),
+		"rankings":   providerRankings,
+	})
+}
+
+// GETCategoryRankings handles GET /v1/rankings/categories
+func (h *RankingsHandler) GETCategoryRankings(c *gin.Context) {
+	// Mock category rankings
+	categories := []gin.H{
+		{
+			"category": "coding",
+			"top_model": "minimax-m2.5",
+			"weekly_tokens": 216000000000,
+			"percentage": 28.6,
+		},
+		{
+			"category": "reasoning",
+			"top_model": "claude-opus-4.6",
+			"weekly_tokens": 150000000000,
+			"percentage": 18.5,
+		},
+		{
+			"category": "multimodal",
+			"top_model": "gemini-3-flash-preview",
+			"weekly_tokens": 120000000000,
+			"percentage": 15.2,
+		},
+		{
+			"category": "general",
+			"top_model": "gpt-5.2",
+			"weekly_tokens": 100000000000,
+			"percentage": 12.8,
+		},
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"updated_at": time.Now(),
+		"categories": categories,
+	})
+}

--- a/pkg/llmproxy/api/handlers/management/usage_analytics.go
+++ b/pkg/llmproxy/api/handlers/management/usage_analytics.go
@@ -1,0 +1,462 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CostAggregationRequest specifies parameters for cost aggregation
+type CostAggregationRequest struct {
+	// StartTime is the start of the aggregation period
+	StartTime time.Time `json:"start_time"`
+	// EndTime is the end of the aggregation period
+	EndTime time.Time `json:"end_time"`
+	// Granularity is the aggregation granularity: hour, day, week, month
+	Granularity string `json:"granularity"`
+	// GroupBy is the grouping: model, provider, client
+	GroupBy string `json:"group_by"`
+	// FilterProvider limits to specific provider
+	FilterProvider string `json:"filter_provider,omitempty"`
+	// FilterModel limits to specific model
+	FilterModel string `json:"filter_model,omitempty"`
+}
+
+// CostAggregationResponse contains aggregated cost data
+type CostAggregationResponse struct {
+	StartTime   time.Time      `json:"start_time"`
+	EndTime     time.Time      `json:"end_time"`
+	Granularity string         `json:"granularity"`
+	GroupBy     string         `json:"group_by"`
+	TotalCost   float64        `json:"total_cost"`
+	TotalTokens int64          `json:"total_tokens"`
+	Groups      []CostGroup    `json:"groups"`
+	TimeSeries  []TimeSeriesPoint `json:"time_series,omitempty"`
+}
+
+// CostGroup represents a grouped cost entry
+type CostGroup struct {
+	Key         string  `json:"key"` // model/provider/client ID
+	Cost        float64 `json:"cost"`
+	InputTokens int64   `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	Requests     int64   `json:"requests"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+}
+
+// TimeSeriesPoint represents a point in time series data
+type TimeSeriesPoint struct {
+	Timestamp    time.Time `json:"timestamp"`
+	Cost        float64   `json:"cost"`
+	InputTokens int64     `json:"input_tokens"`
+	OutputTokens int64     `json:"output_tokens"`
+	Requests    int64     `json:"requests"`
+}
+
+// UsageAnalytics provides usage analytics functionality
+type UsageAnalytics struct {
+	mu            sync.RWMutex
+	records       []UsageRecord
+	maxRecords    int
+}
+
+// UsageRecord represents a single usage record
+type UsageRecord struct {
+	Timestamp    time.Time
+	ModelID      string
+	Provider     string
+	ClientID     string
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	Cost         float64
+	LatencyMs    int
+	Success      bool
+}
+
+// NewUsageAnalytics creates a new UsageAnalytics instance
+func NewUsageAnalytics() *UsageAnalytics {
+	return &UsageAnalytics{
+		records:    make([]UsageRecord, 0),
+		maxRecords: 1000000, // Keep 1M records in memory
+	}
+}
+
+// RecordUsage records a usage event
+func (u *UsageAnalytics) RecordUsage(ctx context.Context, record UsageRecord) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	record.Timestamp = time.Now()
+	u.records = append(u.records, record)
+
+	// Trim if over limit
+	if len(u.records) > u.maxRecords {
+		u.records = u.records[len(u.records)-u.maxRecords:]
+	}
+}
+
+// GetCostAggregation returns aggregated cost data
+func (u *UsageAnalytics) GetCostAggregation(ctx context.Context, req *CostAggregationRequest) (*CostAggregationResponse, error) {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+
+	if req.StartTime.IsZero() {
+		req.StartTime = time.Now().Add(-24 * time.Hour)
+	}
+	if req.EndTime.IsZero() {
+		req.EndTime = time.Now()
+	}
+	if req.Granularity == "" {
+		req.Granularity = "day"
+	}
+	if req.GroupBy == "" {
+		req.GroupBy = "model"
+	}
+
+	// Filter records by time range
+	var filtered []UsageRecord
+	for _, r := range u.records {
+		if r.Timestamp.After(req.StartTime) && r.Timestamp.Before(req.EndTime) {
+			if req.FilterProvider != "" && r.Provider != req.FilterProvider {
+				continue
+			}
+			if req.FilterModel != "" && r.ModelID != req.FilterModel {
+				continue
+			}
+			filtered = append(filtered, r)
+		}
+	}
+
+	// Aggregate by group
+	groups := make(map[string]*CostGroup)
+	var totalCost float64
+	var totalTokens int64
+
+	for _, r := range filtered {
+		var key string
+		switch req.GroupBy {
+		case "model":
+			key = r.ModelID
+		case "provider":
+			key = r.Provider
+		case "client":
+			key = r.ClientID
+		default:
+			key = r.ModelID
+		}
+
+		if _, ok := groups[key]; !ok {
+			groups[key] = &CostGroup{Key: key}
+		}
+
+		g := groups[key]
+		g.Cost += r.Cost
+		g.InputTokens += int64(r.InputTokens)
+		g.OutputTokens += int64(r.OutputTokens)
+		g.Requests++
+		if r.LatencyMs > 0 {
+			g.AvgLatencyMs = (g.AvgLatencyMs*float64(g.Requests-1) + float64(r.LatencyMs)) / float64(g.Requests)
+		}
+
+		totalCost += r.Cost
+		totalTokens += int64(r.TotalTokens)
+	}
+
+	// Convert to slice
+	result := make([]CostGroup, 0, len(groups))
+	for _, g := range groups {
+		result = append(result, *g)
+	}
+
+	// Generate time series
+	var timeSeries []TimeSeriesPoint
+	if len(filtered) > 0 {
+		timeSeries = u.generateTimeSeries(filtered, req.Granularity)
+	}
+
+	return &CostAggregationResponse{
+		StartTime:   req.StartTime,
+		EndTime:     req.EndTime,
+		Granularity: req.Granularity,
+		GroupBy:     req.GroupBy,
+		TotalCost:   totalCost,
+		TotalTokens: totalTokens,
+		Groups:      result,
+		TimeSeries:  timeSeries,
+	}, nil
+}
+
+// generateTimeSeries creates time series data from records
+func (u *UsageAnalytics) generateTimeSeries(records []UsageRecord, granularity string) []TimeSeriesPoint {
+	// Determine bucket size
+	var bucketSize time.Duration
+	switch granularity {
+	case "hour":
+		bucketSize = time.Hour
+	case "day":
+		bucketSize = 24 * time.Hour
+	case "week":
+		bucketSize = 7 * 24 * time.Hour
+	case "month":
+		bucketSize = 30 * 24 * time.Hour
+	default:
+		bucketSize = 24 * time.Hour
+	}
+
+	// Group by time buckets
+	buckets := make(map[int64]*TimeSeriesPoint)
+	for _, r := range records {
+		bucket := r.Timestamp.Unix() / int64(bucketSize.Seconds())
+		if _, ok := buckets[bucket]; !ok {
+			buckets[bucket] = &TimeSeriesPoint{
+				Timestamp: time.Unix(bucket*int64(bucketSize.Seconds()), 0),
+			}
+		}
+		b := buckets[bucket]
+		b.Cost += r.Cost
+		b.InputTokens += int64(r.InputTokens)
+		b.OutputTokens += int64(r.OutputTokens)
+		b.Requests++
+	}
+
+	// Convert to slice and sort
+	result := make([]TimeSeriesPoint, 0, len(buckets))
+	for _, p := range buckets {
+		result = append(result, *p)
+	}
+
+	// Sort by timestamp
+	for i := 0; i < len(result)-1; i++ {
+		for j := i + 1; j < len(result); j++ {
+			if result[j].Timestamp.Before(result[i].Timestamp) {
+				result[i], result[j] = result[j], result[i]
+			}
+		}
+	}
+
+	return result
+}
+
+// GetTopModels returns top models by cost
+func (u *UsageAnalytics) GetTopModels(ctx context.Context, limit int, timeRange time.Duration) ([]CostGroup, error) {
+	req := &CostAggregationRequest{
+		StartTime:  time.Now().Add(-timeRange),
+		EndTime:    time.Now(),
+		Granularity: "day",
+		GroupBy:    "model",
+	}
+
+	resp, err := u.GetCostAggregation(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by cost descending
+	groups := resp.Groups
+	for i := 0; i < len(groups)-1; i++ {
+		for j := i + 1; j < len(groups); j++ {
+			if groups[j].Cost > groups[i].Cost {
+				groups[i], groups[j] = groups[j], groups[i]
+			}
+		}
+	}
+
+	if len(groups) > limit {
+		groups = groups[:limit]
+	}
+
+	return groups, nil
+}
+
+// GetProviderBreakdown returns cost breakdown by provider
+func (u *UsageAnalytics) GetProviderBreakdown(ctx context.Context, timeRange time.Duration) (map[string]float64, error) {
+	req := &CostAggregationRequest{
+		StartTime:  time.Now().Add(-timeRange),
+		EndTime:    time.Now(),
+		Granularity: "day",
+		GroupBy:    "provider",
+	}
+
+	resp, err := u.GetCostAggregation(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]float64)
+	for _, g := range resp.Groups {
+		result[g.Key] = g.Cost
+	}
+
+	return result, nil
+}
+
+// GetDailyTrend returns daily cost trend
+func (u *UsageAnalytics) GetDailyTrend(ctx context.Context, days int) ([]TimeSeriesPoint, error) {
+	req := &CostAggregationRequest{
+		StartTime:  time.Now().Add(time.Duration(-days) * 24 * time.Hour),
+		EndTime:    time.Now(),
+		Granularity: "day",
+		GroupBy:    "model",
+	}
+
+	resp, err := u.GetCostAggregation(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TimeSeries, nil
+}
+
+// GetCostSummary returns a summary of costs
+func (u *UsageAnalytics) GetCostSummary(ctx context.Context, timeRange time.Duration) (map[string]interface{}, error) {
+	req := &CostAggregationRequest{
+		StartTime:  time.Now().Add(-timeRange),
+		EndTime:    time.Now(),
+		Granularity: "day",
+		GroupBy:    "model",
+	}
+
+	resp, err := u.GetCostAggregation(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate additional metrics
+	var totalRequests int64
+	var totalInputTokens, totalOutputTokens int64
+	for _, g := range resp.Groups {
+		totalRequests += g.Requests
+		totalInputTokens += g.InputTokens
+		totalOutputTokens += g.OutputTokens
+	}
+
+	avgCostPerRequest := 0.0
+	if totalRequests > 0 {
+		avgCostPerRequest = resp.TotalCost / float64(totalRequests)
+	}
+
+	return map[string]interface{}{
+		"total_cost":           resp.TotalCost,
+		"total_tokens":         resp.TotalTokens,
+		"total_requests":       totalRequests,
+		"total_input_tokens":    totalInputTokens,
+		"total_output_tokens":  totalOutputTokens,
+		"avg_cost_per_request": avgCostPerRequest,
+		"time_range":           timeRange.String(),
+		"period_start":         req.StartTime,
+		"period_end":           req.EndTime,
+	}, nil
+}
+
+// Example UsageAnalyticsHandler
+type UsageAnalyticsHandler struct {
+	analytics *UsageAnalytics
+}
+
+// NewUsageAnalyticsHandler creates a new handler
+func NewUsageAnalyticsHandler() *UsageAnalyticsHandler {
+	return &UsageAnalyticsHandler{
+		analytics: NewUsageAnalytics(),
+	}
+}
+
+// GETCostSummary handles GET /v1/analytics/costs
+func (h *UsageAnalyticsHandler) GETCostSummary(c *gin.Context) {
+	timeRange := c.DefaultQuery("timeRange", "24h")
+	
+	duration, err := time.ParseDuration(timeRange)
+	if err != nil {
+		duration = 24 * time.Hour
+	}
+
+	summary, err := h.analytics.GetCostSummary(c.Request.Context(), duration)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, summary)
+}
+
+// GETCostAggregation handles GET /v1/analytics/costs/breakdown
+func (h *UsageAnalyticsHandler) GETCostAggregation(c *gin.Context) {
+	var req CostAggregationRequest
+	if err := c.ShouldBindQuery(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	resp, err := h.analytics.GetCostAggregation(c.Request.Context(), &req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// GETTopModels handles GET /v1/analytics/top-models
+func (h *UsageAnalyticsHandler) GETTopModels(c *gin.Context) {
+	limit := 10
+	timeRange := c.DefaultQuery("timeRange", "24h")
+	
+	duration, err := time.ParseDuration(timeRange)
+	if err != nil {
+		duration = 24 * time.Hour
+	}
+
+	topModels, err := h.analytics.GetTopModels(c.Request.Context(), limit, duration)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"limit":      limit,
+		"time_range": timeRange,
+		"top_models": topModels,
+	})
+}
+
+// GETProviderBreakdown handles GET /v1/analytics/provider-breakdown
+func (h *UsageAnalyticsHandler) GETProviderBreakdown(c *gin.Context) {
+	timeRange := c.DefaultQuery("timeRange", "24h")
+	
+	duration, err := time.ParseDuration(timeRange)
+	if err != nil {
+		duration = 24 * time.Hour
+	}
+
+	breakdown, err := h.analytics.GetProviderBreakdown(c.Request.Context(), duration)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"time_range": timeRange,
+		"breakdown":  breakdown,
+	})
+}
+
+// GETDailyTrend handles GET /v1/analytics/daily-trend
+func (h *UsageAnalyticsHandler) GETDailyTrend(c *gin.Context) {
+	days := 7
+	fmt.Sscanf(c.DefaultQuery("days", "7"), "%d", &days)
+
+	trend, err := h.analytics.GetDailyTrend(c.Request.Context(), days)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"days":  days,
+		"trend": trend,
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/llmproxy/api/handlers/management/alerts.go` — alert management endpoints
- Adds `pkg/llmproxy/api/handlers/management/provider_status.go` — provider health/status reporting
- Adds `pkg/llmproxy/api/handlers/management/rankings.go` — provider ranking/scoring endpoints
- Adds `pkg/llmproxy/api/handlers/management/usage_analytics.go` — usage analytics endpoints

These management handler files extend the existing management API surface and were present in the cliproxy-base merge-workspace but not yet on the main branch.

## Test plan

- [ ] Verify `go build ./pkg/llmproxy/api/handlers/management/...` compiles without errors
- [ ] Run existing management tests: `go test ./pkg/llmproxy/api/handlers/management/...`
- [ ] Verify new endpoints are reachable via the management server

🤖 Generated with [Claude Code](https://claude.com/claude-code)