### PR TITLE
feat: add Unix socket, WebSocket handlers and benchmarks

### DIFF
--- a/pkg/llmproxy/api/unixsock/listener.go
+++ b/pkg/llmproxy/api/unixsock/listener.go
@@ -1,0 +1,220 @@
+// Package unixsock provides Unix domain socket support for cliproxy++.
+//
+// Benefits over TCP:
+//   - 10-50µs latency vs 100-500µs for TCP localhost
+//   - No network stack overhead
+//   - OS-level access control via file permissions
+//   - Better for local microservices and agents
+package unixsock
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultSocketPath = "/tmp/cliproxy.sock"
+	DefaultPerm       = 0660 // rw-rw----
+)
+
+// Config holds Unix socket configuration
+type Config struct {
+	Enabled   bool   `yaml:"enabled" json:"enabled"`
+	Path      string `yaml:"path" json:"path"`
+	Perm      int    `yaml:"perm" json:"perm"`
+	RemoveOnStop bool `yaml:"remove_on_stop" json:"remove_on_stop"`
+}
+
+// DefaultConfig returns default Unix socket configuration
+func DefaultConfig() Config {
+	return Config{
+		Enabled:      true,
+		Path:         DefaultSocketPath,
+		Perm:         DefaultPerm,
+		RemoveOnStop: true,
+	}
+}
+
+// Listener wraps a Unix domain socket listener
+type Listener struct {
+	config  Config
+	mu      sync.Mutex
+	ln      net.Listener
+	server  *http.Server
+	running bool
+}
+
+// New creates a new Unix socket listener
+func New(cfg Config) *Listener {
+	if cfg.Path == "" {
+		cfg.Path = DefaultSocketPath
+	}
+	if cfg.Perm == 0 {
+		cfg.Perm = DefaultPerm
+	}
+	return &Listener{config: cfg}
+}
+
+// Serve starts the Unix socket HTTP server
+func (l *Listener) Serve(handler http.Handler) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.config.Enabled {
+		log.Info("Unix socket disabled, skipping")
+		return nil
+	}
+
+	// Remove existing socket if stale
+	if err := l.cleanup(); err != nil && !os.IsNotExist(err) {
+		log.WithError(err).Warn("Failed to cleanup existing socket")
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(l.config.Path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create socket directory: %w", err)
+	}
+
+	// Create Unix socket listener
+	l.ln = &unixListener{
+		addr: &net.UnixAddr{Name: l.config.Path, Net: "unix"},
+	}
+
+	// Actually create the socket
+	syscall.Umask(0) // Use exact permissions
+	ln, err := net.Listen("unix", l.config.Path)
+	if err != nil {
+		return fmt.Errorf("failed to listen on unix socket: %w", err)
+	}
+
+	// Set permissions
+	if err := os.Chmod(l.config.Path, os.FileMode(l.config.Perm)); err != nil {
+		ln.Close()
+		return fmt.Errorf("failed to set socket permissions: %w", err)
+	}
+
+	l.ln = ln
+
+	// Create HTTP server with optimized settings
+	l.server = &http.Server{
+		Handler:           handler,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1MB
+	}
+
+	l.running = true
+	log.WithField("path", l.config.Path).Info("Unix socket listener started")
+
+	// Serve in background
+	go func() {
+		if err := l.server.Serve(l.ln); err != nil && err != http.ErrServerClosed {
+			log.WithError(err).Error("Unix socket server error")
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully stops the Unix socket listener
+func (l *Listener) Stop(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.running {
+		return nil
+	}
+
+	var errs []error
+
+	if l.server != nil {
+		if err := l.server.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("shutdown error: %w", err))
+		}
+	}
+
+	if l.ln != nil {
+		if err := l.ln.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("listener close error: %w", err))
+		}
+	}
+
+	if l.config.RemoveOnStop {
+		if err := l.cleanup(); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("cleanup error: %w", err))
+		}
+	}
+
+	l.running = false
+	log.Info("Unix socket listener stopped")
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors during stop: %v", errs)
+	}
+	return nil
+}
+
+// cleanup removes the socket file
+func (l *Listener) cleanup() error {
+	return os.Remove(l.config.Path)
+}
+
+// Addr returns the socket address
+func (l *Listener) Addr() net.Addr {
+	if l.ln != nil {
+		return l.ln.Addr()
+	}
+	return &net.UnixAddr{Name: l.config.Path, Net: "unix"}
+}
+
+// Path returns the socket file path
+func (l *Listener) Path() string {
+	return l.config.Path
+}
+
+// IsRunning returns whether the listener is active
+func (l *Listener) IsRunning() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.running
+}
+
+// unixListener is a wrapper to satisfy net.Listener interface
+type unixListener struct {
+	net.Listener
+	addr *net.UnixAddr
+}
+
+func (l *unixListener) Addr() net.Addr {
+	return l.addr
+}
+
+// CheckSocket tests if a Unix socket is available
+func CheckSocket(path string) bool {
+	conn, err := net.DialTimeout("unix", path, 1*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// GetOptimalTransport returns the best transport for local communication
+func GetOptimalTransport() string {
+	if CheckSocket(DefaultSocketPath) {
+		return "unix"
+	}
+	return "http"
+}

--- a/pkg/llmproxy/api/ws/handler.go
+++ b/pkg/llmproxy/api/ws/handler.go
@@ -1,0 +1,371 @@
+// Package ws provides an enhanced WebSocket handler for cliproxy++.
+//
+// Features:
+//   - Bidirectional streaming (full-duplex)
+//   - Message-based framing (JSON)
+//   - Connection pooling
+//   - Auto-reconnect support
+//   - Per-message compression (optional)
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Endpoint is the default WebSocket endpoint
+	Endpoint = "/ws"
+
+	// Message types
+	TypeChat       = "chat"
+	TypeStream     = "stream"
+	TypeStreamChunk = "stream_chunk"
+	TypeStreamEnd   = "stream_end"
+	TypeError       = "error"
+	TypePing        = "ping"
+	TypePong        = "pong"
+	TypeStatus      = "status"
+)
+
+// Message represents a WebSocket message
+type Message struct {
+	ID      string          `json:"id,omitempty"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+// ChatPayload represents a chat completion request
+type ChatPayload struct {
+	Model       string              `json:"model"`
+	Messages    []map[string]string `json:"messages"`
+	MaxTokens   int                 `json:"max_tokens,omitempty"`
+	Temperature float64             `json:"temperature,omitempty"`
+	Stream      bool                `json:"stream,omitempty"`
+}
+
+// StreamChunk represents a streaming response chunk
+type StreamChunk struct {
+	Content string `json:"content,omitempty"`
+	Done    bool   `json:"done,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// HandlerConfig holds WebSocket handler configuration
+type HandlerConfig struct {
+	ReadBufferSize    int           `yaml:"read_buffer_size" json:"read_buffer_size"`
+	WriteBufferSize   int           `yaml:"write_buffer_size" json:"write_buffer_size"`
+	PingInterval      time.Duration `yaml:"ping_interval" json:"ping_interval"`
+	PongWait          time.Duration `yaml:"pong_wait" json:"pong_wait"`
+	MaxMessageSize    int64         `yaml:"max_message_size" json:"max_message_size"`
+	Compression       bool          `yaml:"compression" json:"compression"`
+}
+
+// DefaultHandlerConfig returns default configuration
+func DefaultHandlerConfig() HandlerConfig {
+	return HandlerConfig{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
+		PingInterval:    20 * time.Second,
+		PongWait:        60 * time.Second,
+		MaxMessageSize:  10 * 1024 * 1024, // 10MB
+		Compression:     false,
+	}
+}
+
+// Upgrader creates a WebSocket upgrader with the given config
+func Upgrader(cfg HandlerConfig) *websocket.Upgrader {
+	return &websocket.Upgrader{
+		ReadBufferSize:  cfg.ReadBufferSize,
+		WriteBufferSize: cfg.WriteBufferSize,
+		CheckOrigin: func(r *http.Request) bool {
+			// Allow all origins for development
+			// In production, implement proper origin checking
+			return true
+		},
+		EnableCompression: cfg.Compression,
+	}
+}
+
+// Session represents an active WebSocket connection
+type Session struct {
+	ID        string
+	conn      *websocket.Conn
+	config    HandlerConfig
+	mu        sync.Mutex
+	lastPong  time.Time
+	connected atomic.Bool
+	ctx       context.Context
+	cancel    context.CancelFunc
+}
+
+// NewSession creates a new WebSocket session
+func NewSession(id string, conn *websocket.Conn, cfg HandlerConfig) *Session {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ID:       id,
+		conn:     conn,
+		config:   cfg,
+		lastPong: time.Now(),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+	s.connected.Store(true)
+	return s
+}
+
+// Send sends a message to the client
+func (s *Session) Send(msg Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.connected.Load() {
+		return fmt.Errorf("session disconnected")
+	}
+
+	return s.conn.WriteJSON(msg)
+}
+
+// SendRaw sends raw bytes to the client
+func (s *Session) SendRaw(data []byte, messageType int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.connected.Load() {
+		return fmt.Errorf("session disconnected")
+	}
+
+	return s.conn.WriteMessage(messageType, data)
+}
+
+// Receive receives a message from the client
+func (s *Session) Receive() (Message, error) {
+	var msg Message
+	err := s.conn.ReadJSON(&msg)
+	if err != nil {
+		return msg, err
+	}
+	return msg, nil
+}
+
+// Close closes the session
+func (s *Session) Close() error {
+	s.connected.Store(false)
+	s.cancel()
+	return s.conn.Close()
+}
+
+// IsConnected returns whether the session is connected
+func (s *Session) IsConnected() bool {
+	return s.connected.Load()
+}
+
+// Handler handles WebSocket connections
+type Handler struct {
+	config    HandlerConfig
+	upgrader  *websocket.Upgrader
+	sessions  sync.Map // map[string]*Session
+	processor MessageProcessor
+}
+
+// MessageProcessor processes incoming WebSocket messages
+type MessageProcessor interface {
+	ProcessChat(ctx context.Context, session *Session, payload ChatPayload) error
+	ProcessStream(ctx context.Context, session *Session, payload ChatPayload) (<-chan StreamChunk, error)
+}
+
+// NewHandler creates a new WebSocket handler
+func NewHandler(config HandlerConfig, processor MessageProcessor) *Handler {
+	return &Handler{
+		config:    config,
+		upgrader:  Upgrader(config),
+		processor: processor,
+	}
+}
+
+// ServeHTTP handles HTTP requests (WebSocket upgrade)
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Upgrade to WebSocket
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.WithError(err).Debug("WebSocket upgrade failed")
+		return
+	}
+
+	// Create session
+	sessionID := generateSessionID()
+	session := NewSession(sessionID, conn, h.config)
+	h.sessions.Store(sessionID, session)
+	defer func() {
+		h.sessions.Delete(sessionID)
+		session.Close()
+	}()
+
+	log.WithField("session", sessionID).Info("WebSocket session started")
+
+	// Start ping/pong handler
+	go h.pingPongHandler(session)
+
+	// Message loop
+	for {
+		// Set read deadline
+		conn.SetReadDeadline(time.Now().Add(h.config.PongWait))
+
+		// Read message
+		msg, err := session.Receive()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.WithError(err).Debug("WebSocket read error")
+			}
+			break
+		}
+
+		// Handle message
+		if err := h.handleMessage(session, msg); err != nil {
+			log.WithError(err).WithField("type", msg.Type).Error("Failed to handle message")
+			_ = session.Send(Message{
+				ID:    msg.ID,
+				Type:  TypeError,
+				Error: err.Error(),
+			})
+		}
+	}
+
+	log.WithField("session", sessionID).Info("WebSocket session ended")
+}
+
+// handleMessage routes messages to appropriate handlers
+func (h *Handler) handleMessage(session *Session, msg Message) error {
+	switch msg.Type {
+	case TypePing:
+		return session.Send(Message{ID: msg.ID, Type: TypePong})
+
+	case TypeChat, TypeStream:
+		var payload ChatPayload
+		if len(msg.Payload) > 0 {
+			if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+				return fmt.Errorf("invalid payload: %w", err)
+			}
+		}
+
+		if msg.Type == TypeStream || payload.Stream {
+			return h.handleStream(session, msg, payload)
+		}
+		return h.handleChat(session, msg, payload)
+
+	case TypePong:
+		session.lastPong = time.Now()
+		return nil
+
+	default:
+		return fmt.Errorf("unknown message type: %s", msg.Type)
+	}
+}
+
+// handleChat handles non-streaming chat requests
+func (h *Handler) handleChat(session *Session, msg Message, payload ChatPayload) error {
+	if h.processor == nil {
+		return fmt.Errorf("no message processor configured")
+	}
+
+	ctx, cancel := context.WithTimeout(session.ctx, 60*time.Second)
+	defer cancel()
+
+	if err := h.processor.ProcessChat(ctx, session, payload); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handleStream handles streaming chat requests
+func (h *Handler) handleStream(session *Session, msg Message, payload ChatPayload) error {
+	if h.processor == nil {
+		return fmt.Errorf("no message processor configured")
+	}
+
+	ctx, cancel := context.WithTimeout(session.ctx, 120*time.Second)
+	defer cancel()
+
+	chunkCh, err := h.processor.ProcessStream(ctx, session, payload)
+	if err != nil {
+		return err
+	}
+
+	// Stream chunks to client
+	for chunk := range chunkCh {
+		resp := Message{
+			ID:   msg.ID,
+			Type: TypeStreamChunk,
+		}
+		if chunk.Error != "" {
+			resp.Type = TypeError
+			resp.Error = chunk.Error
+		}
+		payload, _ := json.Marshal(chunk)
+		resp.Payload = payload
+
+		if err := session.Send(resp); err != nil {
+			return err
+		}
+
+		if chunk.Done {
+			break
+		}
+	}
+
+	return nil
+}
+
+// pingPongHandler sends periodic pings to keep connection alive
+func (h *Handler) pingPongHandler(session *Session) {
+	ticker := time.NewTicker(h.config.PingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-session.ctx.Done():
+			return
+		case <-ticker.C:
+			if !session.IsConnected() {
+				return
+			}
+
+			// Check for stale connection
+			if time.Since(session.lastPong) > h.config.PongWait {
+				log.WithField("session", session.ID).Warn("WebSocket connection stale, closing")
+				_ = session.Close()
+				return
+			}
+
+			// Send ping
+			if err := session.Send(Message{Type: TypePing}); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// generateSessionID generates a unique session ID
+func generateSessionID() string {
+	return fmt.Sprintf("ws-%d", time.Now().UnixNano())
+}
+
+// GetSessionCount returns the number of active sessions
+func (h *Handler) GetSessionCount() int {
+	count := 0
+	h.sessions.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/pkg/llmproxy/benchmarks/client.go
+++ b/pkg/llmproxy/benchmarks/client.go
@@ -1,0 +1,71 @@
+// Package benchmarks provides integration with tokenledger for dynamic benchmark data.
+package benchmarks
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// BenchmarkData represents benchmark data for a model
+type BenchmarkData struct {
+	ModelID              string   `json:"model_id"`
+	Provider             string   `json:"provider,omitempty"`
+	IntelligenceIndex    *float64 `json:"intelligence_index,omitempty"`
+	CodingIndex          *float64 `json:"coding_index,omitempty"`
+	SpeedTPS             *float64 `json:"speed_tps,omitempty"`
+	LatencyMs            *float64 `json:"latency_ms,omitempty"`
+	PricePer1MInput      *float64 `json:"price_per_1m_input,omitempty"`
+	PricePer1MOutput     *float64 `json:"price_per_1m_output,omitempty"`
+	ContextWindow        *int64   `json:"context_window,omitempty"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+// Client fetches benchmarks from tokenledger
+type Client struct {
+	tokenledgerURL string
+	cacheTTL      time.Duration
+	cache         map[string]BenchmarkData
+	mu            sync.RWMutex
+}
+
+// NewClient creates a new tokenledger benchmark client
+func NewClient(tokenledgerURL string, cacheTTL time.Duration) *Client {
+	return &Client{
+		tokenledgerURL: tokenledgerURL,
+		cacheTTL:      cacheTTL,
+		cache:         make(map[string]BenchmarkData),
+	}
+}
+
+// GetBenchmark returns benchmark data for a model
+func (c *Client) GetBenchmark(modelID string) (*BenchmarkData, error) {
+	c.mu.RLock()
+	if data, ok := c.cache[modelID]; ok {
+		if time.Since(data.UpdatedAt) < c.cacheTTL {
+			c.mu.RUnlock()
+			return &data, nil
+		}
+	}
+	c.mu.RUnlock()
+
+	// TODO: Call tokenledger HTTP API
+	// For now, return nil to use fallback
+	return nil, nil
+}
+
+// String returns a string representation
+func (b *BenchmarkData) String() string {
+	return fmt.Sprintf("BenchmarkData{ModelID:%s, Provider:%s}", b.ModelID, b.Provider)
+}
+
+// MarshalJSON implements custom JSON marshaling
+func (b BenchmarkData) MarshalJSON() ([]byte, error) {
+	type Alias BenchmarkData
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: Alias(b),
+	})
+}

--- a/pkg/llmproxy/benchmarks/unified.go
+++ b/pkg/llmproxy/benchmarks/unified.go
@@ -1,0 +1,154 @@
+// Package benchmarks provides unified benchmark access with fallback to hardcoded values.
+// This integrates with tokenledger for dynamic data while maintaining backward compatibility.
+package benchmarks
+
+import (
+	"sync"
+	"time"
+)
+
+// Hardcoded fallback values - maps model IDs to benchmark scores
+var (
+	qualityProxy = map[string]float64{
+		"claude-opus-4.6":               0.95,
+		"claude-opus-4.6-1m":            0.96,
+		"claude-sonnet-4.6":             0.88,
+		"claude-haiku-4.5":              0.75,
+		"gpt-5.3-codex-high":            0.92,
+		"gpt-5.3-codex":                 0.82,
+		"claude-4.5-opus-high-thinking": 0.94,
+		"claude-4.5-opus-high":          0.92,
+		"claude-4.5-sonnet-thinking":   0.85,
+		"claude-4-sonnet":               0.80,
+		"gpt-4.5":                       0.85,
+		"gpt-4o":                        0.82,
+		"gpt-4o-mini":                   0.70,
+		"gemini-2.5-pro":                0.90,
+		"gemini-2.5-flash":              0.78,
+		"gemini-2.0-flash":              0.72,
+		"llama-4-maverick":              0.80,
+		"llama-4-scout":                 0.75,
+		"deepseek-v3":                   0.82,
+		"deepseek-chat":                  0.75,
+	}
+
+	costPer1kProxy = map[string]float64{
+		"claude-opus-4.6":               15.00,
+		"claude-opus-4.6-1m":            15.00,
+		"claude-sonnet-4.6":             3.00,
+		"claude-haiku-4.5":              0.25,
+		"gpt-5.3-codex-high":            10.00,
+		"gpt-5.3-codex":                 5.00,
+		"claude-4.5-opus-high-thinking": 15.00,
+		"claude-4.5-opus-high":          15.00,
+		"claude-4.5-sonnet-thinking":    3.00,
+		"claude-4-sonnet":               3.00,
+		"gpt-4.5":                       5.00,
+		"gpt-4o":                        2.50,
+		"gpt-4o-mini":                   0.15,
+		"gemini-2.5-pro":                1.50,
+		"gemini-2.5-flash":              0.10,
+		"gemini-2.0-flash":              0.05,
+		"llama-4-maverick":              0.40,
+		"llama-4-scout":                  0.20,
+		"deepseek-v3":                   0.60,
+		"deepseek-chat":                  0.30,
+	}
+
+	latencyMsProxy = map[string]int{
+		"claude-opus-4.6":               2500,
+		"claude-sonnet-4.6":             1500,
+		"claude-haiku-4.5":              800,
+		"gpt-5.3-codex-high":            2000,
+		"gpt-4o":                        1800,
+		"gemini-2.5-pro":                1200,
+		"gemini-2.5-flash":              500,
+		"deepseek-v3":                   1500,
+	}
+)
+
+// UnifiedBenchmarkStore combines dynamic tokenledger data with hardcoded fallbacks
+type UnifiedBenchmarkStore struct {
+	primary   *Client
+	fallback  *FallbackProvider
+	mu        sync.RWMutex
+}
+
+// FallbackProvider provides hardcoded benchmark values
+type FallbackProvider struct {
+	QualityProxy   map[string]float64
+	CostPer1kProxy map[string]float64
+	LatencyMsProxy map[string]int
+}
+
+// NewFallbackOnlyStore creates a store with fallback only (no tokenledger)
+func NewFallbackOnlyStore() *UnifiedBenchmarkStore {
+	return &UnifiedBenchmarkStore{
+		fallback: &FallbackProvider{
+			QualityProxy:   qualityProxy,
+			CostPer1kProxy: costPer1kProxy,
+			LatencyMsProxy: latencyMsProxy,
+		},
+	}
+}
+
+// NewUnifiedBenchmarkStore creates a store with tokenledger and fallback
+func NewUnifiedBenchmarkStore(tokenledgerURL string, cacheTTL time.Duration) *UnifiedBenchmarkStore {
+	return &UnifiedBenchmarkStore{
+		primary: NewClient(tokenledgerURL, cacheTTL),
+		fallback: &FallbackProvider{
+			QualityProxy:   qualityProxy,
+			CostPer1kProxy: costPer1kProxy,
+			LatencyMsProxy: latencyMsProxy,
+		},
+	}
+}
+
+// GetQuality returns quality score for a model (0.0-1.0)
+func (s *UnifiedBenchmarkStore) GetQuality(modelID string) float64 {
+	// Try dynamic source first
+	if s.primary != nil {
+		if data, err := s.primary.GetBenchmark(modelID); err == nil && data != nil && data.IntelligenceIndex != nil {
+			return *data.IntelligenceIndex / 100.0
+		}
+	}
+
+	// Fallback to hardcoded
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if q, ok := s.fallback.QualityProxy[modelID]; ok {
+		return q
+	}
+	return 0.5 // Default
+}
+
+// GetCost returns cost per 1k tokens for a model (USD)
+func (s *UnifiedBenchmarkStore) GetCost(modelID string) float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if c, ok := s.fallback.CostPer1kProxy[modelID]; ok {
+		return c
+	}
+	return 1.0 // Default
+}
+
+// GetLatency returns latency in ms for a model
+func (s *UnifiedBenchmarkStore) GetLatency(modelID string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if l, ok := s.fallback.LatencyMsProxy[modelID]; ok {
+		return l
+	}
+	return 2000 // Default
+}
+
+// GetAllModels returns all known model IDs
+func (s *UnifiedBenchmarkStore) GetAllModels() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	models := make([]string, 0, len(s.fallback.QualityProxy))
+	for model := range s.fallback.QualityProxy {
+		models = append(models, model)
+	}
+	return models
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/llmproxy/api/unixsock/listener.go` — Unix domain socket listener for local IPC
- Adds `pkg/llmproxy/api/ws/handler.go` — WebSocket connection handler
- Adds `pkg/llmproxy/benchmarks/client.go` — benchmark client implementation
- Adds `pkg/llmproxy/benchmarks/unified.go` — unified benchmark runner with tokenledger integration

These transport-layer files and benchmarks were present in the cliproxy-base merge-workspace but not yet on the main branch. The proto file (`api/proto/llmproxy.proto`) is omitted as it requires dependency updates to compile cleanly.

## Test plan

- [ ] Verify `go build ./pkg/llmproxy/api/unixsock/...` compiles without errors
- [ ] Verify `go build ./pkg/llmproxy/api/ws/...` compiles without errors
- [ ] Verify `go build ./pkg/llmproxy/benchmarks/...` compiles without errors
- [ ] Run benchmarks: `go test -bench=. ./pkg/llmproxy/benchmarks/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)