### PR TITLE
feat: recover feat/sdk-openapi-cherry-pick changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,17 @@ _bmad-output/*
 .DS_Store
 ._*
 *.bak
+server
+cli-proxy-api-plus-integration-test
+boardsync
+releasebatch
+.cache
+
+# Build artifacts (cherry-picked from fix/test-cleanups)
+cliproxyapi++
+.air/
+boardsync
+releasebatch
+.cache
+logs/
+


### PR DESCRIPTION
## Summary
- Cherry-pick commit `45bb73de` (SDK/OpenAPI/build tooling recovery) onto main.
- Resolved conflict during transplant by applying `.gitignore` artifact additions from commit.
- Verified `release.yaml` context during review; no conflict was introduced by this cherry-pick.

## Notes
- Cherry-pick target: `45bb73de`
- Cherry-pick result commit: `3c8f9891`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore patterns to exclude additional build artifacts, cache, log files, and project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->