### PR TITLE
migrated: migrated-ci-fix-feature-migrate-1698-strip-empty-messages-openai-to-claude-v2

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,33 @@
+name: Auto Merge Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - labeled
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: |
+      (github.event_name != 'pull_request_review') ||
+      (github.event.review.state == 'APPROVED')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for labeled PRs
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'automerge') &&
+          !contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash

--- a/.worktrees/config/m/config-build/active/pkg/llmproxy/config/sdk_types.go
+++ b/.worktrees/config/m/config-build/active/pkg/llmproxy/config/sdk_types.go
@@ -1,43 +1,8 @@
-// Package config provides configuration types for CLI Proxy API.
-// This file contains SDK-specific config types that are used by internal/* packages.
+// Package config provides configuration types for the llmproxy server.
 package config
 
-// SDKConfig represents the SDK-level configuration embedded in Config.
-type SDKConfig struct {
-	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
-	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
+import sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 
-	// ForceModelPrefix requires explicit model prefixes (e.g., "teamA/gemini-3-pro-preview")
-	// to target prefixed credentials. When false, unprefixed model requests may use prefixed
-	// credentials as well.
-	ForceModelPrefix bool `yaml:"force-model-prefix" json:"force-model-prefix"`
-
-	// RequestLog enables or disables detailed request logging functionality.
-	RequestLog bool `yaml:"request-log" json:"request-log"`
-
-	// APIKeys is a list of keys for authenticating clients to this proxy server.
-	APIKeys []string `yaml:"api-keys" json:"api-keys"`
-
-	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
-	// Default is false (disabled).
-	PassthroughHeaders bool `yaml:"passthrough-headers" json:"passthrough-headers"`
-
-	// Streaming configures server-side streaming behavior (keep-alives and safe bootstrap retries).
-	Streaming StreamingConfig `yaml:"streaming" json:"streaming"`
-
-	// NonStreamKeepAliveInterval controls how often blank lines are emitted for non-streaming responses.
-	// <= 0 disables keep-alives. Value is in seconds.
-	NonStreamKeepAliveInterval int `yaml:"nonstream-keepalive-interval,omitempty" json:"nonstream-keepalive-interval,omitempty"`
-}
-
-// StreamingConfig holds server streaming behavior configuration.
-type StreamingConfig struct {
-	// KeepAliveSeconds controls how often the server emits SSE heartbeats (": keep-alive\n\n").
-	// <= 0 disables keep-alives. Default is 0.
-	KeepAliveSeconds int `yaml:"keepalive-seconds,omitempty" json:"keepalive-seconds,omitempty"`
-
-	// BootstrapRetries controls how many times the server may retry a streaming request before any bytes are sent,
-	// to allow auth rotation / transient recovery.
-	// <= 0 disables bootstrap retries. Default is 0.
-	BootstrapRetries int `yaml:"bootstrap-retries,omitempty" json:"bootstrap-retries,omitempty"`
-}
+// Keep SDK types aligned with public SDK config to avoid split-type regressions.
+type SDKConfig = sdkconfig.SDKConfig
+type StreamingConfig = sdkconfig.StreamingConfig

--- a/pkg/llmproxy/access/reconcile.go
+++ b/pkg/llmproxy/access/reconcile.go
@@ -9,6 +9,7 @@ import (
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -85,7 +86,16 @@ func ApplyAccessProviders(manager *sdkaccess.Manager, oldCfg, newCfg *config.Con
 	}
 
 	existing := manager.Providers()
-	configaccess.Register((*config.SDKConfig)(&newCfg.SDKConfig))
+	sdkCfg := sdkconfig.SDKConfig{
+		ProxyURL:                   newCfg.SDKConfig.ProxyURL,
+		ForceModelPrefix:           newCfg.SDKConfig.ForceModelPrefix,
+		RequestLog:                 newCfg.SDKConfig.RequestLog,
+		APIKeys:                    newCfg.SDKConfig.APIKeys,
+		PassthroughHeaders:         newCfg.SDKConfig.PassthroughHeaders,
+		Streaming:                  sdkconfig.StreamingConfig(newCfg.SDKConfig.Streaming),
+		NonStreamKeepAliveInterval: newCfg.SDKConfig.NonStreamKeepAliveInterval,
+	}
+	configaccess.Register(&sdkCfg)
 	providers, added, updated, removed, err := ReconcileProviders(oldCfg, newCfg, existing)
 	if err != nil {
 		log.Errorf("failed to reconcile request auth providers: %v", err)

--- a/pkg/llmproxy/api/handlers/management/config_basic.go
+++ b/pkg/llmproxy/api/handlers/management/config_basic.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/util"
-	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -45,7 +44,7 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 		proxyURL = strings.TrimSpace(h.cfg.ProxyURL)
 	}
 	if proxyURL != "" {
-		sdkCfg := &sdkconfig.SDKConfig{ProxyURL: proxyURL}
+		sdkCfg := &config.SDKConfig{ProxyURL: proxyURL}
 		util.SetProxy(sdkCfg, client)
 	}
 


### PR DESCRIPTION
Automated migration PR for migrated-ci-fix-feature-migrate-1698-strip-empty-messages-openai-to-claude-v2