### PR TITLE
fix(access): register SDKConfig directly for PR #551

### DIFF
--- a/pkg/llmproxy/access/reconcile.go
+++ b/pkg/llmproxy/access/reconcile.go
@@ -9,7 +9,6 @@ import (
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
-	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -86,16 +85,7 @@ func ApplyAccessProviders(manager *sdkaccess.Manager, oldCfg, newCfg *config.Con
 	}
 
 	existing := manager.Providers()
-	sdkCfg := sdkconfig.SDKConfig{
-		ProxyURL:                   newCfg.SDKConfig.ProxyURL,
-		ForceModelPrefix:           newCfg.SDKConfig.ForceModelPrefix,
-		RequestLog:                 newCfg.SDKConfig.RequestLog,
-		APIKeys:                    newCfg.SDKConfig.APIKeys,
-		PassthroughHeaders:         newCfg.SDKConfig.PassthroughHeaders,
-		Streaming:                  sdkconfig.StreamingConfig(newCfg.SDKConfig.Streaming),
-		NonStreamKeepAliveInterval: newCfg.SDKConfig.NonStreamKeepAliveInterval,
-	}
-	configaccess.Register(&sdkCfg)
+	configaccess.Register(&newCfg.SDKConfig)
 	providers, added, updated, removed, err := ReconcileProviders(oldCfg, newCfg, existing)
 	if err != nil {
 		log.Errorf("failed to reconcile request auth providers: %v", err)


### PR DESCRIPTION
Follow-up fix for review comment on #551.

- Use configaccess.Register(&newCfg.SDKConfig)
- Avoid manual SDKConfig field copy

Cherry-picked commit: 8402c9a6.