### PR TITLE
fix: align sdk codex auth imports with internal types

### DIFF
--- a/sdk/auth/codex.go
+++ b/sdk/auth/codex.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/auth/codex"
-	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/browser"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/browser"
 	// legacy client removed
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
-	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/misc"
-	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/util"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
## Summary
- switch sdk codex login imports from pkg llmproxy auth stack to internal auth stack
- align sdk/auth/codex.go with buildAuthRecord signature in sdk/auth/codex_device.go

## Why
PR #617 fails CodeQL/go build because buildAuthRecord expects internal/auth/codex types while sdk/auth/codex.go constructed pkg/llmproxy/auth/codex types.

## Validation
- fixes compile-time type mismatch in CI for sdk/auth/codex.go
