### PR TITLE
fix: align codex device auth package path

### DIFF
--- a/sdk/auth/codex_device.go
+++ b/sdk/auth/codex_device.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
+	"github.com/router-for-me/CLIProxyAPI/v6/pkg/llmproxy/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/browser"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"


### PR DESCRIPTION
## Summary
- switch sdk/auth/codex_device.go to import codex auth from pkg/llmproxy/auth/codex

## Why
PR #617 currently compiles sdk/auth/codex.go against pkg codex types, while buildAuthRecord in sdk/auth/codex_device.go expected internal codex types.
This aligns both sides to the same package path to remove the compile-time mismatch.
