### PR TITLE
chore(repo): ignore local worktrees and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 cli-proxy-api
 cliproxy
 *.exe
+cli-proxy-api-plus
+server
 
 
 # Configuration
@@ -53,3 +55,4 @@ _bmad-output/*
 .DS_Store
 ._*
 *.bak
+PROJECT-wtrees/


### PR DESCRIPTION
## Summary\n- ignore local worktree root\n- ignore local binary artifacts (CLIProxyAPI Version: dev, Commit: none, BuiltAt: unknown
[2026-02-26 14:45:31] [--------] [error] [main.go:440] failed to load config: failed to read config file: open /Users/kooshapari/CodeProjects/Phenotype/repos/cliproxyapi-plusplus/PROJECT-wtrees/chore-ignore-local-worktrees-artifacts/config.yaml: no such file or directory, )\n\n## Notes\n-  content remains on disk; only ignore rules were updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore additional project-specific paths and binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->