### PR TITLE
config: add missing responses compact enable method

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1118,6 +1118,13 @@ func (cfg *Config) IsResponsesWebsocketEnabled() bool {
 	return *cfg.ResponsesWebsocketEnabled
 }
 
+// IsResponsesCompactEnabled returns true when /responses/compact is enabled.
+// The current internal config surface does not expose a dedicated toggle, so
+// the route remains enabled by default.
+func (cfg *Config) IsResponsesCompactEnabled() bool {
+	return true
+}
+
 // SanitizeOpenAICompatibility removes OpenAI-compatibility provider entries that are
 // not actionable, specifically those missing a BaseURL. It trims whitespace before
 // evaluation and preserves the relative order of remaining entries.


### PR DESCRIPTION
Add missing IsResponsesCompactEnabled method on internal config with default true behavior to unblock PR 617 build and CodeQL compile.