### PR TITLE
api: export WithPostAuthHook alias

### DIFF
--- a/pkg/llmproxy/api/aliases.go
+++ b/pkg/llmproxy/api/aliases.go
@@ -13,6 +13,7 @@ var (
 	WithMiddleware                = api.WithMiddleware
 	WithEngineConfigurator        = api.WithEngineConfigurator
 	WithLocalManagementPassword   = api.WithLocalManagementPassword
+	WithPostAuthHook              = api.WithPostAuthHook
 	WithKeepAliveEndpoint         = api.WithKeepAliveEndpoint
 	WithRequestLoggerFactory      = api.WithRequestLoggerFactory
 	NewServer                     = api.NewServer


### PR DESCRIPTION
Export WithPostAuthHook from pkg/llmproxy/api aliases to match internal/api surface and fix PR 617 build/CodeQL compile failure.