### PR TITLE
refactor: integrate phenotype-go-kit for auth DRY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kooshapari/cliproxyapi-plusplus/v6
 go 1.26.0
 
 require (
+	github.com/KooshaPari/phenotype-go-kit v0.0.0
 	github.com/andybalholm/brotli v1.2.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
@@ -110,3 +111,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/KooshaPari/phenotype-go-kit => ../../template-commons/phenotype-go-kit

--- a/internal/auth/claude/anthropic_auth.go
+++ b/internal/auth/claude/anthropic_auth.go
@@ -285,13 +285,12 @@ func (o *ClaudeAuth) RefreshTokens(ctx context.Context, refreshToken string) (*C
 // Returns:
 //   - *ClaudeTokenStorage: A new token storage instance
 func (o *ClaudeAuth) CreateTokenStorage(bundle *ClaudeAuthBundle) *ClaudeTokenStorage {
-	storage := &ClaudeTokenStorage{
-		AccessToken:  bundle.TokenData.AccessToken,
-		RefreshToken: bundle.TokenData.RefreshToken,
-		LastRefresh:  bundle.LastRefresh,
-		Email:        bundle.TokenData.Email,
-		Expire:       bundle.TokenData.Expire,
-	}
+	storage := NewClaudeTokenStorage("")
+	storage.AccessToken = bundle.TokenData.AccessToken
+	storage.RefreshToken = bundle.TokenData.RefreshToken
+	storage.LastRefresh = bundle.LastRefresh
+	storage.Email = bundle.TokenData.Email
+	storage.Expire = bundle.TokenData.Expire
 
 	return storage
 }

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -4,62 +4,33 @@
 package claude
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
+	"github.com/KooshaPari/phenotype-go-kit/pkg/auth"
 	"github.com/kooshapari/cliproxyapi-plusplus/v6/internal/misc"
 )
 
-func sanitizeTokenFilePath(path string) (string, error) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
-		return "", fmt.Errorf("token file path is empty")
-	}
-	return filepath.Clean(trimmed), nil
-}
-
 // ClaudeTokenStorage stores OAuth2 token information for Anthropic Claude API authentication.
-// It maintains compatibility with the existing auth system while adding Claude-specific fields
-// for managing access tokens, refresh tokens, and user account information.
+// It extends the shared BaseTokenStorage with Claude-specific functionality,
+// maintaining compatibility with the existing auth system.
 type ClaudeTokenStorage struct {
-	// IDToken is the JWT ID token containing user claims and identity information.
-	IDToken string `json:"id_token"`
-
-	// AccessToken is the OAuth2 access token used for authenticating API requests.
-	AccessToken string `json:"access_token"`
-
-	// RefreshToken is used to obtain new access tokens when the current one expires.
-	RefreshToken string `json:"refresh_token"`
-
-	// LastRefresh is the timestamp of the last token refresh operation.
-	LastRefresh string `json:"last_refresh"`
-
-	// Email is the Anthropic account email address associated with this token.
-	Email string `json:"email"`
-
-	// Type indicates the authentication provider type, always "claude" for this storage.
-	Type string `json:"type"`
-
-	// Expire is the timestamp when the current access token expires.
-	Expire string `json:"expired"`
-
-	// Metadata holds arbitrary key-value pairs injected via hooks.
-	// It is not exported to JSON directly to allow flattening during serialization.
-	Metadata map[string]any `json:"-"`
+	*auth.BaseTokenStorage
 }
 
-// SetMetadata allows external callers to inject metadata into the storage before saving.
-func (ts *ClaudeTokenStorage) SetMetadata(meta map[string]any) {
-	ts.Metadata = meta
+// NewClaudeTokenStorage creates a new Claude token storage with the given file path.
+//
+// Parameters:
+//   - filePath: The full path where the token file should be saved/loaded
+//
+// Returns:
+//   - *ClaudeTokenStorage: A new Claude token storage instance
+func NewClaudeTokenStorage(filePath string) *ClaudeTokenStorage {
+	return &ClaudeTokenStorage{
+		BaseTokenStorage: auth.NewBaseTokenStorage(filePath),
+	}
 }
 
 // SaveTokenToFile serializes the Claude token storage to a JSON file.
-// This method creates the necessary directory structure and writes the token
-// data in JSON format to the specified file path for persistent storage.
-// It merges any injected metadata into the top-level JSON object.
+// This method wraps the base implementation to provide logging compatibility
+// with the existing system.
 //
 // Parameters:
 //   - authFilePath: The full path where the token file should be saved
@@ -70,36 +41,16 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "claude"
 
-	safePath, err := sanitizeTokenFilePath(authFilePath)
-	if err != nil {
-		return fmt.Errorf("invalid token file path: %w", err)
-	}
+	// Create a new token storage with the file path and copy the fields
+	base := auth.NewBaseTokenStorage(authFilePath)
+	base.IDToken = ts.IDToken
+	base.AccessToken = ts.AccessToken
+	base.RefreshToken = ts.RefreshToken
+	base.LastRefresh = ts.LastRefresh
+	base.Email = ts.Email
+	base.Type = ts.Type
+	base.Expire = ts.Expire
+	base.SetMetadata(ts.Metadata)
 
-	misc.LogSavingCredentials(safePath)
-
-	// Create directory structure if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
-		return fmt.Errorf("failed to create directory: %v", err)
-	}
-
-	// Create the token file
-	f, err := os.Create(safePath)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	// Merge metadata using helper
-	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
-	if errMerge != nil {
-		return fmt.Errorf("failed to merge metadata: %w", errMerge)
-	}
-
-	// Encode and write the token data as JSON
-	if err = json.NewEncoder(f).Encode(data); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
-	}
-	return nil
+	return base.Save()
 }

--- a/internal/auth/copilot/copilot_auth.go
+++ b/internal/auth/copilot/copilot_auth.go
@@ -166,15 +166,15 @@ func (c *CopilotAuth) ValidateToken(ctx context.Context, accessToken string) (bo
 
 // CreateTokenStorage creates a new CopilotTokenStorage from auth bundle.
 func (c *CopilotAuth) CreateTokenStorage(bundle *CopilotAuthBundle) *CopilotTokenStorage {
-	return &CopilotTokenStorage{
-		AccessToken: bundle.TokenData.AccessToken,
-		TokenType:   bundle.TokenData.TokenType,
-		Scope:       bundle.TokenData.Scope,
-		Username:    bundle.Username,
-		Email:       bundle.Email,
-		Name:        bundle.Name,
-		Type:        "github-copilot",
-	}
+	storage := NewCopilotTokenStorage("")
+	storage.AccessToken = bundle.TokenData.AccessToken
+	storage.TokenType = bundle.TokenData.TokenType
+	storage.Scope = bundle.TokenData.Scope
+	storage.Username = bundle.Username
+	storage.Email = bundle.Email
+	storage.Name = bundle.Name
+	storage.Type = "github-copilot"
+	return storage
 }
 
 // LoadAndValidateToken loads a token from storage and validates it.

--- a/internal/auth/copilot/token.go
+++ b/internal/auth/copilot/token.go
@@ -4,20 +4,16 @@
 package copilot
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-
+	"github.com/KooshaPari/phenotype-go-kit/pkg/auth"
 	"github.com/kooshapari/cliproxyapi-plusplus/v6/internal/misc"
 )
 
 // CopilotTokenStorage stores OAuth2 token information for GitHub Copilot API authentication.
-// It maintains compatibility with the existing auth system while adding Copilot-specific fields
-// for managing access tokens and user account information.
+// It extends the shared BaseTokenStorage with Copilot-specific fields for managing
+// GitHub user profile information.
 type CopilotTokenStorage struct {
-	// AccessToken is the OAuth2 access token used for authenticating API requests.
-	AccessToken string `json:"access_token"`
+	*auth.BaseTokenStorage
+
 	// TokenType is the type of token, typically "bearer".
 	TokenType string `json:"token_type"`
 	// Scope is the OAuth2 scope granted to the token.
@@ -26,12 +22,21 @@ type CopilotTokenStorage struct {
 	ExpiresAt string `json:"expires_at,omitempty"`
 	// Username is the GitHub username associated with this token.
 	Username string `json:"username"`
-	// Email is the GitHub email address associated with this token.
-	Email string `json:"email,omitempty"`
 	// Name is the GitHub display name associated with this token.
 	Name string `json:"name,omitempty"`
-	// Type indicates the authentication provider type, always "github-copilot" for this storage.
-	Type string `json:"type"`
+}
+
+// NewCopilotTokenStorage creates a new Copilot token storage with the given file path.
+//
+// Parameters:
+//   - filePath: The full path where the token file should be saved/loaded
+//
+// Returns:
+//   - *CopilotTokenStorage: A new Copilot token storage instance
+func NewCopilotTokenStorage(filePath string) *CopilotTokenStorage {
+	return &CopilotTokenStorage{
+		BaseTokenStorage: auth.NewBaseTokenStorage(filePath),
+	}
 }
 
 // CopilotTokenData holds the raw OAuth token response from GitHub.
@@ -71,8 +76,8 @@ type DeviceCodeResponse struct {
 }
 
 // SaveTokenToFile serializes the Copilot token storage to a JSON file.
-// This method creates the necessary directory structure and writes the token
-// data in JSON format to the specified file path for persistent storage.
+// This method wraps the base implementation to provide logging compatibility
+// with the existing system.
 //
 // Parameters:
 //   - authFilePath: The full path where the token file should be saved
@@ -82,20 +87,17 @@ type DeviceCodeResponse struct {
 func (ts *CopilotTokenStorage) SaveTokenToFile(authFilePath string) error {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "github-copilot"
-	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
-		return fmt.Errorf("failed to create directory: %v", err)
-	}
 
-	f, err := os.Create(authFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
+	// Create a new token storage with the file path and copy the fields
+	base := auth.NewBaseTokenStorage(authFilePath)
+	base.IDToken = ts.IDToken
+	base.AccessToken = ts.AccessToken
+	base.RefreshToken = ts.RefreshToken
+	base.LastRefresh = ts.LastRefresh
+	base.Email = ts.Email
+	base.Type = ts.Type
+	base.Expire = ts.Expire
+	base.SetMetadata(ts.Metadata)
 
-	if err = json.NewEncoder(f).Encode(ts); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
-	}
-	return nil
+	return base.Save()
 }

--- a/internal/auth/gemini/gemini_auth.go
+++ b/internal/auth/gemini/gemini_auth.go
@@ -203,13 +203,12 @@ func (g *GeminiAuth) createTokenStorage(ctx context.Context, config *oauth2.Conf
 	ifToken["scopes"] = Scopes
 	ifToken["universe_domain"] = "googleapis.com"
 
-	ts := GeminiTokenStorage{
-		Token:     ifToken,
-		ProjectID: projectID,
-		Email:     emailResult.String(),
-	}
+	ts := NewGeminiTokenStorage("")
+	ts.Token = ifToken
+	ts.ProjectID = projectID
+	ts.Email = emailResult.String()
 
-	return &ts, nil
+	return ts, nil
 }
 
 // getTokenFromWeb initiates the web-based OAuth2 authorization flow.

--- a/internal/auth/gemini/gemini_token.go
+++ b/internal/auth/gemini/gemini_token.go
@@ -4,52 +4,48 @@
 package gemini
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
+	"github.com/KooshaPari/phenotype-go-kit/pkg/auth"
 	"github.com/kooshapari/cliproxyapi-plusplus/v6/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // GeminiTokenStorage stores OAuth2 token information for Google Gemini API authentication.
-// It maintains compatibility with the existing auth system while adding Gemini-specific fields
-// for managing access tokens, refresh tokens, and user account information.
+// It extends the shared BaseTokenStorage with Gemini-specific fields for managing
+// Google Cloud Project information.
 type GeminiTokenStorage struct {
+	*auth.BaseTokenStorage
+
 	// Token holds the raw OAuth2 token data, including access and refresh tokens.
 	Token any `json:"token"`
 
 	// ProjectID is the Google Cloud Project ID associated with this token.
 	ProjectID string `json:"project_id"`
 
-	// Email is the email address of the authenticated user.
-	Email string `json:"email"`
-
 	// Auto indicates if the project ID was automatically selected.
 	Auto bool `json:"auto"`
 
 	// Checked indicates if the associated Cloud AI API has been verified as enabled.
 	Checked bool `json:"checked"`
-
-	// Type indicates the authentication provider type, always "gemini" for this storage.
-	Type string `json:"type"`
-
-	// Metadata holds arbitrary key-value pairs injected via hooks.
-	// It is not exported to JSON directly to allow flattening during serialization.
-	Metadata map[string]any `json:"-"`
 }
 
-// SetMetadata allows external callers to inject metadata into the storage before saving.
-func (ts *GeminiTokenStorage) SetMetadata(meta map[string]any) {
-	ts.Metadata = meta
+// NewGeminiTokenStorage creates a new Gemini token storage with the given file path.
+//
+// Parameters:
+//   - filePath: The full path where the token file should be saved/loaded
+//
+// Returns:
+//   - *GeminiTokenStorage: A new Gemini token storage instance
+func NewGeminiTokenStorage(filePath string) *GeminiTokenStorage {
+	return &GeminiTokenStorage{
+		BaseTokenStorage: auth.NewBaseTokenStorage(filePath),
+	}
 }
 
 // SaveTokenToFile serializes the Gemini token storage to a JSON file.
-// This method creates the necessary directory structure and writes the token
-// data in JSON format to the specified file path for persistent storage.
-// It merges any injected metadata into the top-level JSON object.
+// This method wraps the base implementation to provide logging compatibility
+// with the existing system.
 //
 // Parameters:
 //   - authFilePath: The full path where the token file should be saved
@@ -59,31 +55,19 @@ func (ts *GeminiTokenStorage) SetMetadata(meta map[string]any) {
 func (ts *GeminiTokenStorage) SaveTokenToFile(authFilePath string) error {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "gemini"
-	// Merge metadata using helper
-	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
-	if errMerge != nil {
-		return fmt.Errorf("failed to merge metadata: %w", errMerge)
-	}
-	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
-		return fmt.Errorf("failed to create directory: %v", err)
-	}
 
-	f, err := os.Create(authFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to create token file: %w", err)
-	}
-	defer func() {
-		if errClose := f.Close(); errClose != nil {
-			log.Errorf("failed to close file: %v", errClose)
-		}
-	}()
+	// Create a new token storage with the file path and copy the fields
+	base := auth.NewBaseTokenStorage(authFilePath)
+	base.IDToken = ts.IDToken
+	base.AccessToken = ts.AccessToken
+	base.RefreshToken = ts.RefreshToken
+	base.LastRefresh = ts.LastRefresh
+	base.Email = ts.Email
+	base.Type = ts.Type
+	base.Expire = ts.Expire
+	base.SetMetadata(ts.Metadata)
 
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(data); err != nil {
-		return fmt.Errorf("failed to write token to file: %w", err)
-	}
-	return nil
+	return base.Save()
 }
 
 // CredentialFileName returns the filename used to persist Gemini CLI credentials.


### PR DESCRIPTION
## Summary
- Add phenotype-go-kit as dependency with local replace directive
- Refactor Claude, Copilot, Gemini auth providers to embed BaseTokenStorage
- ~200 lines of duplicated token storage boilerplate eliminated
- All providers implement shared TokenStorage interface

## Test plan
- [ ] go build ./... passes
- [ ] go test ./... passes
- [ ] Auth flows work end-to-end for Claude, Copilot, Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)