### PR TITLE
chore: add governance files (CLAUDE.md, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Project — AI Agent Instructions
+
+This file guides Claude agents working on this project.
+
+## Scope
+
+- Full project ownership: implementation, testing, documentation, PR preparation
+- Authority: create branches, commits, PRs, merge to main (via PR)
+
+## Process
+
+1. **Pre-work**: Check AgilePlus for specs (`agileplus list`)
+2. **Implementation**: Work in feature branch at `repos/worktrees/<project>/<category>/<feature>`
+3. **Testing**: Run quality checks locally before pushing
+4. **PR prep**: Ensure all checks pass before requesting merge
+5. **Integration**: Rebase/restack if needed, merge to main via PR
+
+## Quality Standards
+
+- All tests pass locally
+- Lint: 0 errors
+- Coverage: ≥80% (or project default)
+- Documentation updated for new features
+
+## Integration Points
+
+- Coordinate with Phenotype shared packages
+- Cross-repo updates tracked in AgilePlus
+
+## Escalation
+
+- Blocking issues: surface in AgilePlus worklog
+- Design decisions: document in ADR files
+- Architecture changes: reference governance framework

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# cliproxyapi-plusplus — Project Instructions
+
+## Governance
+
+This project follows Phenotype governance standards.
+
+## Branch Discipline
+
+- Feature branches: `repos/worktrees/<project>/<category>/<branch>`
+- Canonical repository tracks `main` only
+- Return to `main` for merge/integration checkpoints
+
+## Work Requirements
+
+1. Check for AgilePlus spec before implementing
+2. Create spec for new work: `agileplus specify --title "<feature>" --description "<desc>"`
+3. Update work package status: `agileplus status <feature-id> --wp <wp-id> --state <state>`
+4. No code without corresponding AgilePlus spec
+
+## Release Channels
+
+- `releases/alpha` — Development releases
+- `releases/beta` — Pre-production releases
+- `releases/stable` — Production-ready releases
+
+## Quality Gates
+
+From project root:
+- `go vet ./...` — Run Go vet
+- `go test ./...` — Run test suite
+- `task quality` — Full quality check (linter, tests, coverage)
+
+## Reference
+
+- AgilePlus: `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
+- Global instructions: `~/.claude/CLAUDE.md`
+- Phenotype workspace: `/Users/kooshapari/CodeProjects/Phenotype/CLAUDE.md`


### PR DESCRIPTION
Add standard governance files for Phenotype projects.

## Changes
- Add CLAUDE.md with project governance standards
- Add AGENTS.md with AI agent coordination guidelines

## Release Branches
Created in this repo:
- releases/alpha
- releases/beta  
- releases/stable

## Reference
- Phenotype governance: `/Users/kooshapari/CodeProjects/Phenotype/CLAUDE.md`
- Global instructions: `~/.claude/CLAUDE.md`