### PR TITLE
Add Kilo Gastown methodology spec (GUPP, Worktree Discipline, Governance)

### DIFF
--- a/docs/plans/KILO_GASTOWN_SPEC.md
+++ b/docs/plans/KILO_GASTOWN_SPEC.md
@@ -117,6 +117,26 @@ The `gt_list_convoys` command provides progress visibility across all active con
 4. **Verify** — Run lint/typecheck/tests before submission
 5. **Done** — Push branch, call `gt_done` to submit for review
 
+### GUPP Principle
+
+Work is on your hook — execute immediately. Do not announce what you will do; just do it. When you receive a bead (work item), start working on it right away. No preamble, no status updates, no asking for permission. Produce code, commits, and results.
+
+---
+
+## Worktree Discipline
+
+Worktrees isolate feature branches from the main checkout:
+
+- Primary checkout remains on `main`
+- Feature work happens in `.worktrees/` directories
+- Naming convention: `convoy__<project>__<bead_id>__gt__<agent_name>__<bead_id>`
+- Treat `PROJECT-wtrees/` as migration-only legacy layout
+
+**In cliproxyapi++:**
+- Each polecat works in its own worktree within `.worktrees/`
+- Worktrees are ephemeral — push frequently to avoid data loss
+- Never do development work on the main checkout
+
 ---
 
 ## Applying Kilo to cliproxyapi++ Development
@@ -164,6 +184,33 @@ When requesting bot reviews (CodeRabbit, Gemini Code Assist):
 3. After two consecutive rate-limit responses, stop auto-retries and post status
 4. Required marker format: `bot-review-trigger: <bot> <iso8601-time> <reason>`
 
+**Retrigger commands:**
+| Bot | Command |
+|-----|---------|
+| CodeRabbit | `@coderabbitai full review` |
+| Gemini Code Assist | `@gemini-code-assist review` or `/gemini review` |
+
+---
+
+## Governance Principles
+
+### Phenotype Governance Overlay v1
+
+- Enforce `TDD + BDD + SDD` for all feature and workflow changes
+- Enforce `Hexagonal + Clean + SOLID` boundaries by default
+- Favor explicit failures over silent degradation
+- Required dependencies must fail clearly when unavailable
+- Keep local hot paths deterministic and low-latency
+- Place distributed workflow logic behind durable orchestration boundaries
+- Require policy gating, auditability, and traceable correlation IDs for agent and workflow actions
+
+### Development Philosophy
+
+- **Extend, Never Duplicate**: Refactor rather than create v2 files
+- **Generic First**: Build primitives before application logic (provider interface + registry)
+- **Library First**: Use existing OSS libraries before custom implementations
+- **Config Driven**: Template strings and config over hardcoded messages
+
 ---
 
 ## Quality Gates
@@ -176,6 +223,58 @@ Before calling `gt_done`, polecats must verify:
 | Lint | `golangci-lint run` | 0 errors |
 | Vet | `go vet ./...` | 0 errors |
 | Format | `go fmt ./...` | No diff |
+| Max function length | lint | 40 lines |
+| TODOs | lint | Not allowed |
+
+### Pre-Submission Flow
+
+1. Run all quality gates
+2. If any gate fails, fix and re-run
+3. After two consecutive failures, call `gt_escalate`
+4. Call `gt_done` to submit for review
+
+---
+
+## Coordination Mechanisms
+
+### Mail (gt_mail_send)
+
+Typed messages for coordination:
+- Persistent and queued
+- Delivered on next agent idle moment
+- Use for status sharing and questions
+
+### Nudges (gt_nudge)
+
+Time-sensitive coordination:
+- Immediate delivery at agent's next idle moment
+- Modes: `immediate`, `wait-idle`, `queue`
+- Use for wake-ups and blocking issues
+
+### Escalation (gt_escalate)
+
+Unresolvable issues:
+- Creates an escalation bead
+- Routes to supervisor or mayor
+- Use when stuck after multiple attempts
+
+---
+
+## Kush Ecosystem
+
+This project is part of the Kush multi-repo system:
+
+```
+kush/
+├── thegent/         # Agent orchestration
+├── agentapi++/      # HTTP API for coding agents
+├── cliproxy++/      # LLM proxy with multi-provider support (this repo)
+├── tokenledger/     # Token and cost tracking
+├── 4sgm/           # Python tooling workspace
+├── civ/             # Deterministic simulation
+├── parpour/        # Spec-first planning
+└── pheno-sdk/      # Python SDK
+```
 
 ---
 
@@ -183,9 +282,9 @@ Before calling `gt_done`, polecats must verify:
 
 - [cliproxyapi++ SPEC.md](./SPEC.md) — Technical architecture
 - [cliproxyapi++ FEATURE_CHANGES_PLUSPLUS.md](./FEATURE_CHANGES_PLUSPLUS.md) — ++ vs baseline changes
-- [Kush multi-repo system overview](../AGENTS.md)
+- [Kush AGENTS.md](../AGENTS.md) — Full Kilo Gastown methodology reference
 
 ---
 
-**Document version:** 1.0  
+**Document version:** 1.1  
 **Last updated:** 2026-03-31


### PR DESCRIPTION
## Summary
- Add GUPP Principle and Worktree Discipline sections to KILO_GASTOWN_SPEC.md
- Add Bot Review Retrigger Governance with command reference table
- Add Governance Principles (Phenotype Overlay v1, Development Philosophy)
- Add Coordination Mechanisms (Mail, Nudges, Escalation)
- Add Kush Ecosystem overview diagram
- Update Quality Gates: max function 40 lines, no TODOs
- Update document version to 1.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates with no production code or runtime behavior changes.
> 
> **Overview**
> Updates `docs/plans/KILO_GASTOWN_SPEC.md` to add **GUPP** execution guidance, **worktree discipline** rules, and a **bot review retrigger** policy (including commands for CodeRabbit and Gemini).
> 
> Adds **governance principles** (Phenotype overlay + development philosophy), expands **quality gates** (40-line max functions, no TODOs, pre-submission flow), documents **coordination mechanisms** (`gt_mail_send`, `gt_nudge`, `gt_escalate`), and includes a **Kush ecosystem** overview; bumps the spec version to **1.1**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e285d44959860b23cadd1f1bfe12f1bef58fd12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->