### PR TITLE
fix(security): urlguard for go/request-forgery (closes SEC-1/2/3, bot #848, #808)

### DIFF
--- a/pkg/llmproxy/auth/kiro/sso_oidc.go
+++ b/pkg/llmproxy/auth/kiro/sso_oidc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/browser"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/config"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/util"
+	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/util/urlguard"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -59,6 +60,14 @@ var (
 	ErrSlowDown             = errors.New("slow_down")
 	awsRegionPattern        = regexp.MustCompile(`^[a-z]{2}(?:-[a-z0-9]+)+-\d+$`)
 )
+
+// guardURL validates a constructed outbound URL against the urlguard
+// allowlist before it is handed to net/http. Centralizing this here lets
+// every call site in this file participate in CodeQL go/request-forgery
+// remediation without duplicating the import + check pattern.
+func guardURL(rawURL string) (string, error) {
+	return urlguard.ValidateOutboundURL(rawURL)
+}
 
 // SSOOIDCClient handles AWS SSO OIDC authentication.
 type SSOOIDCClient struct {
@@ -274,7 +283,11 @@ func (c *SSOOIDCClient) RegisterClientWithRegion(ctx context.Context, region str
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/client/register", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(endpoint + "/client/register")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +340,11 @@ func (c *SSOOIDCClient) StartDeviceAuthorizationWithIDC(ctx context.Context, cli
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/device_authorization", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(endpoint + "/device_authorization")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +395,11 @@ func (c *SSOOIDCClient) CreateTokenWithRegion(ctx context.Context, clientID, cli
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/token", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(endpoint + "/token")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +468,11 @@ func (c *SSOOIDCClient) RefreshTokenWithRegion(ctx context.Context, clientID, cl
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/token", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(endpoint + "/token")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -663,7 +688,11 @@ func (c *SSOOIDCClient) RegisterClient(ctx context.Context) (*RegisterClientResp
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/client/register", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/client/register")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +736,11 @@ func (c *SSOOIDCClient) StartDeviceAuthorization(ctx context.Context, clientID, 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/device_authorization", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/device_authorization")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -752,7 +785,11 @@ func (c *SSOOIDCClient) CreateToken(ctx context.Context, clientID, clientSecret,
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/token", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/token")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -810,7 +847,11 @@ func (c *SSOOIDCClient) RefreshToken(ctx context.Context, clientID, clientSecret
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/token", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/token")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -1008,7 +1049,11 @@ func (c *SSOOIDCClient) FetchUserEmail(ctx context.Context, accessToken string) 
 
 // tryUserInfoEndpoint attempts to get user info from AWS SSO OIDC userinfo endpoint.
 func (c *SSOOIDCClient) tryUserInfoEndpoint(ctx context.Context, accessToken string) string {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ssoOIDCEndpoint+"/userinfo", nil)
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/userinfo")
+	if gerr != nil {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, guardedURL, nil)
 	if err != nil {
 		return ""
 	}
@@ -1078,7 +1123,11 @@ func (c *SSOOIDCClient) tryListProfiles(ctx context.Context, accessToken string)
 		return ""
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://codewhisperer.us-east-1.amazonaws.com", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL("https://codewhisperer.us-east-1.amazonaws.com")
+	if gerr != nil {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return ""
 	}
@@ -1135,7 +1184,11 @@ func (c *SSOOIDCClient) tryListCustomizations(ctx context.Context, accessToken s
 		return ""
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://codewhisperer.us-east-1.amazonaws.com", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL("https://codewhisperer.us-east-1.amazonaws.com")
+	if gerr != nil {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return ""
 	}
@@ -1198,7 +1251,11 @@ func (c *SSOOIDCClient) RegisterClientForAuthCode(ctx context.Context, redirectU
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/client/register", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/client/register")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}
@@ -1347,7 +1404,11 @@ func (c *SSOOIDCClient) CreateTokenWithAuthCode(ctx context.Context, clientID, c
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ssoOIDCEndpoint+"/token", strings.NewReader(string(body)))
+	guardedURL, gerr := guardURL(ssoOIDCEndpoint + "/token")
+	if gerr != nil {
+		return nil, gerr
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/llmproxy/executor/antigravity_executor.go
+++ b/pkg/llmproxy/executor/antigravity_executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/registry"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/thinking"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/util"
+	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/util/urlguard"
 	sdkAuth "github.com/kooshapari/CLIProxyAPI/v7/sdk/auth"
 	cliproxyauth "github.com/kooshapari/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/kooshapari/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -1017,7 +1018,11 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			requestURL.WriteString(url.QueryEscape(opts.Alt))
 		}
 
-		httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(payload))
+		guardedURL, gerr := urlguard.ValidateOutboundURL(requestURL.String())
+		if gerr != nil {
+			return cliproxyexecutor.Response{}, gerr
+		}
+		httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, guardedURL, bytes.NewReader(payload))
 		if errReq != nil {
 			return cliproxyexecutor.Response{}, errReq
 		}
@@ -1134,7 +1139,13 @@ func FetchAntigravityModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *c
 
 	for idx, baseURL := range baseURLs {
 		modelsURL := baseURL + antigravityModelsPath
-		httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, modelsURL, bytes.NewReader([]byte(`{}`)))
+		guardedModelsURL, gerr := urlguard.ValidateOutboundURL(modelsURL)
+		if gerr != nil {
+			log.Warnf("antigravity executor: fetch models rejected by urlguard: %v", gerr)
+			lastErr = gerr
+			continue
+		}
+		httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, guardedModelsURL, bytes.NewReader([]byte(`{}`)))
 		if errReq != nil {
 			log.Warnf("antigravity executor: fetch models failed for %s: create request error: %v", auth.ID, errReq)
 			lastErr = errReq
@@ -1350,7 +1361,11 @@ func (e *AntigravityExecutor) refreshToken(ctx context.Context, auth *cliproxyau
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(form.Encode()))
+	guardedTokenURL, gerr := urlguard.ValidateOutboundURL("https://oauth2.googleapis.com/token")
+	if gerr != nil {
+		return auth, gerr
+	}
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, guardedTokenURL, strings.NewReader(form.Encode()))
 	if errReq != nil {
 		return auth, errReq
 	}
@@ -1519,7 +1534,11 @@ func (e *AntigravityExecutor) buildRequest(ctx context.Context, auth *cliproxyau
 		payloadStr, _ = sjson.Delete(payloadStr, "request.generationConfig.maxOutputTokens")
 	}
 
-	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), strings.NewReader(payloadStr))
+	guardedReqURL, gerr := urlguard.ValidateOutboundURL(requestURL.String())
+	if gerr != nil {
+		return nil, gerr
+	}
+	httpReq, errReq := http.NewRequestWithContext(ctx, http.MethodPost, guardedReqURL, strings.NewReader(payloadStr))
 	if errReq != nil {
 		return nil, errReq
 	}

--- a/pkg/llmproxy/util/urlguard/urlguard.go
+++ b/pkg/llmproxy/util/urlguard/urlguard.go
@@ -1,0 +1,87 @@
+// Package urlguard provides outbound URL validation against a hostname
+// allowlist to mitigate Server-Side Request Forgery (SSRF) — CodeQL
+// rule go/request-forgery.
+//
+// Each subsystem that issues outbound HTTP from an URL whose components
+// (region, base URL, etc.) originate from configuration or auth credentials
+// MUST run the URL through ValidateOutboundURL before passing it to
+// http.NewRequest / http.Get / client.Do.
+//
+// The allowlist is a set of suffix patterns matched against the parsed URL
+// hostname. Patterns starting with "." match any subdomain
+// (e.g. ".amazonaws.com" matches "oidc.us-east-1.amazonaws.com" but not
+// "evilamazonaws.com"). Exact hostnames are also supported.
+package urlguard
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Allowlist is the canonical set of hostname suffix patterns the proxy is
+// permitted to dial. Keep ordered by subsystem and add a comment for each
+// entry explaining the call site.
+//
+// Patterns:
+//   - ".example.com"  → any subdomain of example.com
+//   - "host.example"  → exact hostname only
+var Allowlist = []string{
+	// AWS SSO OIDC + CodeWhisperer (Kiro auth flows)
+	".amazonaws.com",
+	// Google Antigravity / Cloud Code (executor base URLs)
+	".googleapis.com",
+	// Google OAuth token endpoint (antigravity refresh)
+	"oauth2.googleapis.com",
+}
+
+// ValidateOutboundURL parses rawURL and returns it unchanged if the host
+// matches any entry in Allowlist. Otherwise it returns an error describing
+// the rejected host. Schemes other than http/https are always rejected.
+//
+// This function is the security boundary for go/request-forgery alerts; do
+// not bypass it with a comment-only suppression.
+func ValidateOutboundURL(rawURL string) (string, error) {
+	return ValidateOutboundURLAgainst(rawURL, Allowlist)
+}
+
+// ValidateOutboundURLAgainst is the testable form of ValidateOutboundURL
+// that accepts an explicit allowlist.
+func ValidateOutboundURLAgainst(rawURL string, allowlist []string) (string, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return "", fmt.Errorf("urlguard: empty URL")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("urlguard: parse %q: %w", rawURL, err)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return "", fmt.Errorf("urlguard: scheme %q not allowed", parsed.Scheme)
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("urlguard: missing host in %q", rawURL)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("urlguard: userinfo not allowed in outbound URL")
+	}
+	for _, pattern := range allowlist {
+		p := strings.ToLower(strings.TrimSpace(pattern))
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(p, ".") {
+			suffix := p[1:]
+			if host == suffix || strings.HasSuffix(host, p) {
+				return trimmed, nil
+			}
+			continue
+		}
+		if host == p {
+			return trimmed, nil
+		}
+	}
+	return "", fmt.Errorf("urlguard: host %q not in allowlist", host)
+}

--- a/pkg/llmproxy/util/urlguard/urlguard_test.go
+++ b/pkg/llmproxy/util/urlguard/urlguard_test.go
@@ -1,0 +1,39 @@
+package urlguard
+
+import "testing"
+
+func TestValidateOutboundURL_Allowed(t *testing.T) {
+	cases := []string{
+		"https://oidc.us-east-1.amazonaws.com/token",
+		"https://codewhisperer.us-east-1.amazonaws.com",
+		"https://cloudcode-pa.googleapis.com/v1/models",
+		"https://oauth2.googleapis.com/token",
+	}
+	for _, u := range cases {
+		got, err := ValidateOutboundURL(u)
+		if err != nil {
+			t.Errorf("ValidateOutboundURL(%q) error: %v", u, err)
+			continue
+		}
+		if got != u {
+			t.Errorf("ValidateOutboundURL(%q) = %q; want unchanged", u, got)
+		}
+	}
+}
+
+func TestValidateOutboundURL_Rejected(t *testing.T) {
+	cases := []string{
+		"",
+		"not a url",
+		"file:///etc/passwd",
+		"https://evil.example.com/",
+		"http://169.254.169.254/latest/meta-data/",
+		"https://user:pass@oidc.us-east-1.amazonaws.com/",
+		"https://evilamazonaws.com/",
+	}
+	for _, u := range cases {
+		if _, err := ValidateOutboundURL(u); err == nil {
+			t.Errorf("ValidateOutboundURL(%q) unexpectedly allowed", u)
+		}
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary

- Add `pkg/llmproxy/util/urlguard` — outbound-URL allowlist + `ValidateOutboundURL` (stdlib only, no new deps)
- Gate every `http.NewRequestWithContext` site in `pkg/llmproxy/auth/kiro/sso_oidc.go` and `pkg/llmproxy/executor/antigravity_executor.go` through `urlguard.ValidateOutboundURL` before the URL reaches `net/http`
- Allowlist is sourced from existing call-site contexts:
  - `.amazonaws.com` (AWS SSO OIDC + CodeWhisperer / Kiro)
  - `.googleapis.com` (Antigravity / Cloud Code)
  - `oauth2.googleapis.com` (Antigravity refresh)

## Why

CodeQL's go/request-forgery dataflow does not see the upstream `isValidAWSRegion` / `validateAntigravityBaseURL` guards. Adding an explicit allowlist check at every NewRequest call site:

1. Closes CodeQL alerts SEC-1 (#373), SEC-2 (#374), SEC-3 (#375) and the bot-mirrored issues #848, #808.
2. Adds defence-in-depth so a future regression in upstream validators still cannot reach an unintended host.
3. Rejects userinfo-bearing URLs and non-http(s) schemes.

Per `repos/docs/governance/cliproxyapi-security-triage-2026-04.md` priority 1.

## Test plan

- [x] `go test ./pkg/llmproxy/util/urlguard/...` passes (allow + reject cases)
- [x] `gofmt -e` clean on changed files
- [ ] CodeQL re-scan auto-closes #848 and #808 once the alert-sync workflow runs

## Notes

- Pure Go (Phenotype scripting policy)
- No third-party dep added; stdlib `net/url` only
- Pre-existing build failures in `pkg/llmproxy/auth/qwen`, `pkg/llmproxy/auth/gemini`, `pkg/llmproxy/auth/kiro/aws_auth.go`, `sdk/cliproxy/auth/manager_ops.go` etc. exist on `main` and are out of scope for this security PR

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Adds a new outbound URL allowlist check that can cause authentication/executor HTTP calls to fail if legitimate endpoints fall outside the configured patterns, impacting login/refresh and model/execution flows. The change is security-motivated and localized but touches multiple network request paths.
> 
> **Overview**
> Introduces `pkg/llmproxy/util/urlguard`, a stdlib-only outbound URL validator that enforces an HTTP(S)-only, no-userinfo policy and a hostname allowlist (AWS `.amazonaws.com`, Google `.googleapis.com`, and `oauth2.googleapis.com`) to mitigate SSRF / CodeQL `go/request-forgery`.
> 
> Routes all constructed outbound `http.NewRequestWithContext` URLs in Kiro AWS SSO OIDC flows (`sso_oidc.go`) and Antigravity executor flows (`antigravity_executor.go`, including token refresh, model fetch, count-tokens, and request execution) through `urlguard.ValidateOutboundURL` before issuing requests, returning/continuing on validation failure. Adds unit tests covering allowed and rejected URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9211ba595c71ffbf470ff7ff521fe8bbd16b58f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Block outbound requests to unapproved hosts**

### What Changed
- Added an outbound URL check that only allows requests to approved AWS and Google domains.
- Applied the check to Kiro and Antigravity requests before they are sent, including token, device authorization, model fetch, and refresh flows.
- Rejected empty URLs, non-web schemes, URLs with login details, and hosts outside the allowlist.

### Impact
`✅ Lower risk of unintended outbound requests`
`✅ Safer sign-in and token refresh flows`
`✅ Clearer rejection of invalid request URLs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=NOAakTXXBKxAywwEwAo2YivlHNfquhN_lUcJRM-jG9A&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
