### PR TITLE
fix(build): repair kiro auth package compilation (round 3)

### DIFF
--- a/pkg/llmproxy/auth/kiro/codewhisperer_client.go
+++ b/pkg/llmproxy/auth/kiro/codewhisperer_client.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/config"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/util"
 	log "github.com/sirupsen/logrus"

--- a/pkg/llmproxy/auth/kiro/fingerprint.go
+++ b/pkg/llmproxy/auth/kiro/fingerprint.go
@@ -195,3 +195,46 @@ func (fp *Fingerprint) BuildAmzUserAgent() string {
 		fp.KiroHash,
 	)
 }
+
+// FingerprintConfig defines configurable Kiro fingerprint identity overrides
+// loaded from application config. Empty fields fall back to the randomized
+// defaults produced by FingerprintManager.generateFingerprint.
+type FingerprintConfig struct {
+	OIDCSDKVersion      string
+	RuntimeSDKVersion   string
+	StreamingSDKVersion string
+	OSType              string
+	OSVersion           string
+	NodeVersion         string
+	KiroVersion         string
+	KiroHash            string
+}
+
+var (
+	globalFingerprintConfig   *FingerprintConfig
+	globalFingerprintConfigMu sync.RWMutex
+)
+
+// SetGlobalFingerprintConfig stores process-wide fingerprint overrides.
+// Subsequent fingerprint generation will apply non-empty fields from cfg
+// on top of the randomized defaults.
+func SetGlobalFingerprintConfig(cfg *FingerprintConfig) {
+	globalFingerprintConfigMu.Lock()
+	defer globalFingerprintConfigMu.Unlock()
+	globalFingerprintConfig = cfg
+}
+
+// GetGlobalFingerprintConfig returns the current process-wide fingerprint
+// override config, or nil if none has been set.
+func GetGlobalFingerprintConfig() *FingerprintConfig {
+	globalFingerprintConfigMu.RLock()
+	defer globalFingerprintConfigMu.RUnlock()
+	return globalFingerprintConfig
+}
+
+// GlobalFingerprintManager is a function-form alias for the process-wide
+// FingerprintManager singleton, kept for callers that use the
+// `kiro.GlobalFingerprintManager()` spelling instead of GetGlobalFingerprintManager.
+func GlobalFingerprintManager() *FingerprintManager {
+	return GetGlobalFingerprintManager()
+}

--- a/pkg/llmproxy/auth/kiro/runtime_helpers.go
+++ b/pkg/llmproxy/auth/kiro/runtime_helpers.go
@@ -152,13 +152,20 @@ func setRuntimeHeaders(req *http.Request, accessToken string, accountKey string)
 }
 
 // FetchProfileArn is the exported wrapper around the internal sso_oidc.go
-// fetchProfileArn helper. It delegates to the unexported method so callers
-// outside this file (such as oauth_web.go) can resolve a profile ARN
-// without exposing transport details. clientID and refreshToken are
-// accepted for forward compatibility (per-account fingerprinting) but
-// the underlying API call only requires the access token.
+// fetchProfileArn helper. It resolves a profile ARN for a given account.
+//
+// clientID and refreshToken are used to derive a deterministic per-account
+// key so the global FingerprintManager warms (or reuses) a stable
+// fingerprint for this account before the underlying request runs. The
+// internal fetchProfileArn call itself only needs the access token, but
+// warming the fingerprint here keeps subsequent runtime calls (which use
+// setRuntimeHeaders with the same account key) consistent with what was
+// used during ARN resolution.
 func (c *SSOOIDCClient) FetchProfileArn(ctx context.Context, accessToken, clientID, refreshToken string) string {
-	_ = clientID
-	_ = refreshToken
+	// Warm/establish the per-account fingerprint. GetAccountKey is
+	// deterministic, so later setRuntimeHeaders calls with the same
+	// (clientID, refreshToken) pair will retrieve the same fingerprint.
+	accountKey := GetAccountKey(clientID, refreshToken)
+	_ = GetGlobalFingerprintManager().GetFingerprint(accountKey)
 	return c.fetchProfileArn(ctx, accessToken)
 }

--- a/pkg/llmproxy/auth/kiro/sso_oidc.go
+++ b/pkg/llmproxy/auth/kiro/sso_oidc.go
@@ -614,7 +614,7 @@ func (c *SSOOIDCClient) LoginWithIDC(ctx context.Context, startURL, region strin
 			profileArn := c.fetchProfileArn(ctx, tokenResp.AccessToken)
 
 			// Fetch user email
-			email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken)
+			email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken, regResp.ClientID, tokenResp.RefreshToken)
 			if email != "" {
 				fmt.Printf("  Logged in as: %s\n", email)
 			}
@@ -1005,7 +1005,7 @@ func (c *SSOOIDCClient) LoginWithBuilderID(ctx context.Context) (*KiroTokenData,
 			profileArn := c.fetchProfileArn(ctx, tokenResp.AccessToken)
 
 			// Fetch user email (tries CodeWhisperer API first, then userinfo endpoint, then JWT parsing)
-			email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken)
+			email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken, regResp.ClientID, tokenResp.RefreshToken)
 			if email != "" {
 				fmt.Printf("  Logged in as: %s\n", email)
 			}
@@ -1542,7 +1542,7 @@ func (c *SSOOIDCClient) LoginWithBuilderIDAuthCode(ctx context.Context) (*KiroTo
 		profileArn := c.fetchProfileArn(ctx, tokenResp.AccessToken)
 
 		// Fetch user email (tries CodeWhisperer API first, then userinfo endpoint, then JWT parsing)
-		email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken)
+		email := FetchUserEmailWithFallback(ctx, c.cfg, tokenResp.AccessToken, regResp.ClientID, tokenResp.RefreshToken)
 		if email != "" {
 			fmt.Printf("  Logged in as: %s\n", email)
 		}

--- a/pkg/llmproxy/auth/kiro/token.go
+++ b/pkg/llmproxy/auth/kiro/token.go
@@ -3,8 +3,6 @@ package kiro
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/auth/base"
 	"os"
 	"path/filepath"
 	"strings"

--- a/pkg/llmproxy/config/config.go
+++ b/pkg/llmproxy/config/config.go
@@ -154,6 +154,24 @@ type Config struct {
 	// ResponsesCompactEnabled controls whether OpenAI Responses API compact mode is active.
 	// Default (nil) is treated as enabled.
 	ResponsesCompactEnabled *bool `yaml:"responses-compact-enabled,omitempty" json:"responses-compact-enabled,omitempty"`
+
+	// KiroFingerprint configures the Kiro/CodeWhisperer fingerprint manager.
+	// When nil, fingerprint defaults from kiro.NewFingerprintManager are used.
+	KiroFingerprint *KiroFingerprintConfig `yaml:"kiro-fingerprint,omitempty" json:"kiro-fingerprint,omitempty"`
+}
+
+// KiroFingerprintConfig defines configurable Kiro fingerprint identity fields.
+// All fields are optional; empty fields fall back to the randomized defaults
+// produced by the kiro FingerprintManager.
+type KiroFingerprintConfig struct {
+	OIDCSDKVersion      string `yaml:"oidc-sdk-version,omitempty" json:"oidc-sdk-version,omitempty"`
+	RuntimeSDKVersion   string `yaml:"runtime-sdk-version,omitempty" json:"runtime-sdk-version,omitempty"`
+	StreamingSDKVersion string `yaml:"streaming-sdk-version,omitempty" json:"streaming-sdk-version,omitempty"`
+	OSType              string `yaml:"os-type,omitempty" json:"os-type,omitempty"`
+	OSVersion           string `yaml:"os-version,omitempty" json:"os-version,omitempty"`
+	NodeVersion         string `yaml:"node-version,omitempty" json:"node-version,omitempty"`
+	KiroVersion         string `yaml:"kiro-version,omitempty" json:"kiro-version,omitempty"`
+	KiroHash            string `yaml:"kiro-hash,omitempty" json:"kiro-hash,omitempty"`
 }
 
 // IsResponsesCompactEnabled returns whether responses compact mode is enabled.


### PR DESCRIPTION
## **User description**
## Summary

Repairs deep symbol drift in `pkg/llmproxy/auth/kiro/` so the package compiles cleanly against current `main` (after #956 + #958 merged).

- Add `KiroFingerprintConfig` type + `Config.KiroFingerprint` field; add `FingerprintConfig`, `SetGlobalFingerprintConfig`, `GlobalFingerprintManager()` alias to fingerprint.go.
- Update three `FetchUserEmailWithFallback` call sites in sso_oidc.go to pass `clientID` + `refreshToken` (5-arg signature).
- Wire exported `FetchProfileArn` to warm the per-account fingerprint via `GetAccountKey(clientID, refreshToken)` before delegating, so subsequent runtime calls reuse a consistent fingerprint per account.
- Drop stale `uuid` import in codewhisperer_client.go and stale `auth/base` import in token.go.

## Symbols restored

| Symbol | Where |
|---|---|
| `config.Config.KiroFingerprint` + `KiroFingerprintConfig` | pkg/llmproxy/config/config.go |
| `kiro.FingerprintConfig` | pkg/llmproxy/auth/kiro/fingerprint.go |
| `kiro.SetGlobalFingerprintConfig` / `GetGlobalFingerprintConfig` | pkg/llmproxy/auth/kiro/fingerprint.go |
| `kiro.GlobalFingerprintManager()` (function alias) | pkg/llmproxy/auth/kiro/fingerprint.go |
| `FetchProfileArn` proper wiring (no longer no-op forwarding) | pkg/llmproxy/auth/kiro/runtime_helpers.go |

## Verification

`go build ./pkg/llmproxy/auth/kiro/...` — clean (0 errors).

## Out of scope (still failing on main)

- pkg/llmproxy/translator/openai/claude/...
- pkg/llmproxy/translator/openai/gemini-cli/...
- pkg/llmproxy/translator/claude/gemini-cli/...
- sdk/auth/{codex,kiro,errors}.go

## Test plan

- [x] `go build ./pkg/llmproxy/auth/kiro/...` succeeds
- [ ] CI build/test (expected to fail on the out-of-scope packages above)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches Kiro OAuth/CodeWhisperer authentication and request header fingerprinting; while largely a compile/symbol-drift fix, it can change runtime header identity and email lookup behavior per account.
> 
> **Overview**
> **Repairs Kiro auth package symbol drift so it builds again** by reintroducing fingerprint configuration types and config plumbing (`Config.KiroFingerprint`, `kiro.FingerprintConfig`, global getters/setters, and `GlobalFingerprintManager()` alias).
> 
> **Aligns per-account identity usage in runtime requests** by updating `SSOOIDCClient.FetchProfileArn` to derive an `accountKey` from `(clientID, refreshToken)` and warm the fingerprint manager, and by updating `FetchUserEmailWithFallback` call sites to pass `clientID`/`refreshToken` to match its newer signature.
> 
> Also removes stale/unused imports in `codewhisperer_client.go` and `token.go` that were breaking compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e083ee222b137f53e263ae5d83bb2413efafd94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Restore Kiro login flow and allow fingerprint overrides**

### What Changed
- Kiro auth now compiles and runs with the current login and profile lookup flow.
- Login now fetches the user email with the required account details, so the email shown after sign-in works again.
- Profile lookup now prepares a stable per-account fingerprint before the request, keeping later runtime requests aligned for the same account.
- A new config option lets operators override Kiro fingerprint details such as SDK, OS, and version fields.

### Impact
`✅ Working Kiro sign-in`
`✅ Clearer login identity display`
`✅ Consistent account fingerprinting`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=7j0Yq6jtgvCwxiQblBkRpQK2KmlN6pRdZF9EEW7f2mQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
