### PR TITLE
docs: first-run quick start (local Go) + minimal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,31 @@ All third-party provider support is maintained by community contributors; clipro
 - Docker (optional)
 - Provider credentials for target upstreams
 
-### Quick Start
+### Quick Start (local Go)
+
+The fastest path to a running proxy on localhost. Uses the bundled minimal config.
+
+```bash
+# Clone and enter the repo
+git clone https://github.com/KooshaPari/cliproxyapi-plusplus.git
+cd cliproxyapi-plusplus
+
+# Copy the minimal first-run config and edit api-keys / claude-api-key
+cp config.minimal.yaml config.yaml
+$EDITOR config.yaml
+
+# Run the server (binds 0.0.0.0:8317)
+go run ./cmd/server --config config.yaml
+
+# Smoke test from another shell
+curl -H "Authorization: Bearer <your api-keys entry>" \
+     http://127.0.0.1:8317/v1/models
+```
+
+For the full schema (TLS, OAuth providers, routing, quotas, management API), see
+[`config.example.yaml`](./config.example.yaml). Drop fields into `config.yaml` as you need them.
+
+### Quick Start (Docker)
 
 ```bash
 # Create deployment directory
@@ -52,18 +76,21 @@ services:
     restart: unless-stopped
 EOF
 
-# Download example config
-curl -o config.yaml https://raw.githubusercontent.com/kooshapari/cliproxyapi-plusplus/main/config.example.yaml
+# Download minimal config (or grab config.example.yaml for the full schema)
+curl -o config.yaml https://raw.githubusercontent.com/KooshaPari/cliproxyapi-plusplus/main/config.minimal.yaml
 
 # Pull and start
 docker compose pull && docker compose up -d
 ```
 
-### Docker Quick Start
-
 ```bash
 docker run -p 8317:8317 eceasy/cli-proxy-api-plus:latest
 ```
+
+### Configuration
+
+- [`config.minimal.yaml`](./config.minimal.yaml) — ~25 lines, everything you need to boot the proxy with a static Claude API key. Start here.
+- [`config.example.yaml`](./config.example.yaml) — full annotated schema (~430 lines): every provider, OAuth, routing, TLS, management API, quotas. Reference only — copy fields into your `config.yaml` as needed.
 
 ## Operations and Security
 

--- a/config.minimal.yaml
+++ b/config.minimal.yaml
@@ -1,0 +1,26 @@
+# Minimal config for first-run.
+# See config.example.yaml for the full schema (TLS, OAuth, routing, quotas, etc.).
+#
+# Start the server:
+#   go run ./cmd/server --config config.minimal.yaml
+# Or via Docker; see README "Quick Start".
+
+# Bind to all interfaces; use "127.0.0.1" to restrict to local only.
+host: ''
+port: 8317
+
+# Where provider auth tokens / OAuth state are persisted.
+auth-dir: '~/.cli-proxy-api'
+
+# Client-facing API keys. Callers must send one of these as a Bearer token.
+# Generate with: openssl rand -hex 32
+api-keys:
+  - 'replace-with-generated-key'
+
+# Static Claude (Anthropic) API key for upstream calls.
+# Get one at https://console.anthropic.com/.
+claude-api-key:
+  - api-key: 'sk-ant-REPLACE_ME'
+
+# Optional: enable verbose logs while bringing the proxy up for the first time.
+debug: true


### PR DESCRIPTION
## Summary

Resolves first-run friction surfaced in `userstory-cliproxyapi-firstrun-2026-04-26`:

- README Quick Start was Docker-only; no local `go run` path for someone with a Go toolchain.
- The only config example was `config.example.yaml` (430 lines, every provider/OAuth/routing knob), with no minimal starting point — first-run users had to read the whole file to figure out what is required.

### Changes

- **`config.minimal.yaml`** (new, ~25 lines): host/port, `auth-dir`, one `api-keys` entry, one static `claude-api-key`, `debug: true`. Bootable as-is after replacing the two placeholder values.
- **`README.md`**:
  - New "Quick Start (local Go)" section with `git clone` -> `cp config.minimal.yaml config.yaml` -> `go run ./cmd/server --config config.yaml` -> curl smoke test.
  - Existing Docker quick start retained (paths already correct: `cmd/server`, `config.example.yaml`).
  - Docker block now points at `config.minimal.yaml` for download.
  - New "Configuration" section linking both `config.minimal.yaml` (start here) and `config.example.yaml` (full schema reference).

### Verification

- `cmd/server` confirmed via `gh api repos/KooshaPari/cliproxyapi-plusplus/contents/cmd` (entries: boardsync, cliproxyctl, codegen, fetch_antigravity_models, mcpdebug, protocheck, releasebatch, **server**).
- `config.example.yaml` confirmed at repo root.
- `claude-api-key` field shape taken from `config.example.yaml` lines 156-181.

## Test plan

- [ ] `cp config.minimal.yaml config.yaml`, fill placeholders, `go run ./cmd/server --config config.yaml` boots clean.
- [ ] `curl -H "Authorization: Bearer <api-keys[0]>" http://127.0.0.1:8317/v1/models` returns 200.
- [ ] Docker quick start with downloaded `config.minimal.yaml` boots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config addition with no runtime code changes; main risk is minor confusion if the minimal config’s placeholders or binding to `0.0.0.0` are misused.
> 
> **Overview**
> Improves first-run setup by adding a new `config.minimal.yaml` that contains only the required fields to boot the proxy (host/port, `auth-dir`, `api-keys`, static `claude-api-key`, optional `debug`).
> 
> Updates `README.md` to include a **local `go run` quick start**, switches the Docker quick start to download the minimal config by default, and adds a short **Configuration** section pointing users to the minimal vs full example config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6679d76d5990a50b5540a4952da5df5de61be59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->