### PR TITLE
[codex] fix CodeQL URL and Cursor JSON hardening

### DIFF
--- a/pkg/llmproxy/api/handlers/management/api_call.go
+++ b/pkg/llmproxy/api/handlers/management/api_call.go
@@ -201,11 +201,7 @@ func (h *Handler) APICall(c *gin.Context) {
 		req.Host = hostOverride
 	}
 
-	httpClient := &http.Client{
-		Timeout: defaultAPICallTimeout,
-	}
-	httpClient.Transport = h.apiCallTransport(auth)
-
+	httpClient := h.apiCallHTTPClient(auth)
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
 		log.WithError(errDo).Debug("management APICall request failed")

--- a/pkg/llmproxy/api/handlers/management/api_call_guard.go
+++ b/pkg/llmproxy/api/handlers/management/api_call_guard.go
@@ -1,0 +1,50 @@
+package management
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+func guardedAPICallDialContext(ctx context.Context, network string, addr string) (net.Conn, error) {
+	host, port, errSplit := net.SplitHostPort(addr)
+	if errSplit != nil {
+		return nil, fmt.Errorf("invalid dial address: %w", errSplit)
+	}
+	resolved, errResolve := resolveAllowedAPICallHostIPs(host)
+	if errResolve != nil {
+		return nil, errResolve
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("target host resolution failed")
+	}
+	dialer := &net.Dialer{}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(resolved[0].IP.String(), port))
+}
+
+type apiCallGuardedRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t apiCallGuardedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+	if errValidate := validateAPICallRequestURL(req.URL); errValidate != nil {
+		return nil, errValidate
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+func validateAPICallRequestURL(reqURL *url.URL) error {
+	if errValidate := validateAPICallURL(reqURL); errValidate != nil {
+		return errValidate
+	}
+	return validateResolvedHostIPs(reqURL.Hostname())
+}

--- a/pkg/llmproxy/api/handlers/management/api_call_transport_test.go
+++ b/pkg/llmproxy/api/handlers/management/api_call_transport_test.go
@@ -1,0 +1,50 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type apiCallRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f apiCallRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestAPICallGuardedRoundTripperRejectsUnsafeRequestURL(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	transport := apiCallGuardedRoundTripper{
+		base: apiCallRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, errors.New("base transport should not run")
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:8317/ping", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if _, err := transport.RoundTrip(req); err == nil {
+		t.Fatalf("RoundTrip error = nil, want unsafe target rejection")
+	}
+	if called {
+		t.Fatal("base transport ran for unsafe URL")
+	}
+}
+
+func TestAPICallRequestURLValidationRejectsUnsafeRedirectURL(t *testing.T) {
+	t.Parallel()
+
+	redirectURL, err := url.Parse("http://localhost:8317/ping")
+	if err != nil {
+		t.Fatalf("parse redirect url: %v", err)
+	}
+	req := &http.Request{URL: redirectURL}
+	if err := validateAPICallRequestURL(req.URL); err == nil {
+		t.Fatalf("validation error = nil, want unsafe redirect rejection")
+	}
+}

--- a/pkg/llmproxy/api/handlers/management/api_call_url.go
+++ b/pkg/llmproxy/api/handlers/management/api_call_url.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -59,23 +60,33 @@ func sanitizeAPICallURL(raw string) (string, *url.URL, error) {
 }
 
 func validateResolvedHostIPs(host string) error {
+	_, err := resolveAllowedAPICallHostIPs(host)
+	return err
+}
+
+func resolveAllowedAPICallHostIPs(host string) ([]net.IPAddr, error) {
 	trimmed := strings.TrimSpace(host)
 	if trimmed == "" {
-		return fmt.Errorf("invalid url host")
+		return nil, fmt.Errorf("invalid url host")
 	}
-	resolved, errLookup := net.LookupIP(trimmed)
+	resolved, errLookup := net.DefaultResolver.LookupIPAddr(context.Background(), trimmed)
 	if errLookup != nil {
-		return fmt.Errorf("target host resolution failed")
+		return nil, fmt.Errorf("target host resolution failed")
 	}
+	allowed := make([]net.IPAddr, 0, len(resolved))
 	for _, ip := range resolved {
-		if ip == nil {
+		if ip.IP == nil {
 			continue
 		}
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-			return fmt.Errorf("target host is not allowed")
+		if ip.IP.IsLoopback() || ip.IP.IsPrivate() || ip.IP.IsUnspecified() || ip.IP.IsMulticast() || ip.IP.IsLinkLocalUnicast() || ip.IP.IsLinkLocalMulticast() {
+			return nil, fmt.Errorf("target host is not allowed")
 		}
+		allowed = append(allowed, ip)
 	}
-	return nil
+	if len(allowed) == 0 {
+		return nil, fmt.Errorf("target host resolution failed")
+	}
+	return allowed, nil
 }
 
 func isAllowedHostOverride(parsedURL *url.URL, override string) bool {

--- a/pkg/llmproxy/api/handlers/management/http_transport.go
+++ b/pkg/llmproxy/api/handlers/management/http_transport.go
@@ -46,7 +46,21 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 	}
 	clone := transport.Clone()
 	clone.Proxy = nil
+	clone.DialContext = guardedAPICallDialContext
 	return clone
+}
+
+func (h *Handler) apiCallHTTPClient(auth *coreauth.Auth) *http.Client {
+	return &http.Client{
+		Timeout:   defaultAPICallTimeout,
+		Transport: apiCallGuardedRoundTripper{base: h.apiCallTransport(auth)},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			return validateAPICallRequestURL(req.URL)
+		},
+	}
 }
 
 func buildProxyTransportWithError(proxyStr string) (*http.Transport, error) {

--- a/pkg/llmproxy/executor/cursor_executor.go
+++ b/pkg/llmproxy/executor/cursor_executor.go
@@ -333,11 +333,13 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	id := "chatcmpl-" + uuid.New().String()[:28]
 	created := time.Now().Unix()
-	openaiResp := fmt.Sprintf(`{"id":"%s","object":"chat.completion","created":%d,"model":"%s","choices":[{"index":0,"message":{"role":"assistant","content":%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
-		id, created, parsed.Model, jsonString(fullText.String()))
+	openaiResp, errMarshal := cursorCompletionJSON(id, created, parsed.Model, fullText.String())
+	if errMarshal != nil {
+		return resp, fmt.Errorf("cursor: failed to encode response: %w", errMarshal)
+	}
 
 	// Translate response back to source format if needed
-	result := []byte(openaiResp)
+	result := openaiResp
 	if from.String() != "" && from.String() != "openai" {
 		var param any
 		result = sdktranslator.TranslateNonStream(ctx, to, from, req.Model, bytes.Clone(opts.OriginalRequest), payload, result, &param)
@@ -536,13 +538,13 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	// Wrap sendChunk/sendDone to use emitToOut
 	sendChunkSwitchable := func(delta string, finishReason string) {
-		fr := "null"
-		if finishReason != "" {
-			fr = finishReason
+		openaiJSON, errMarshal := cursorChunkJSON(chatId, created, parsed.Model, json.RawMessage(delta), finishReason)
+		if errMarshal != nil {
+			log.Warnf("cursor: failed to encode stream chunk: %v", errMarshal)
+			return
 		}
-		openaiJSON := fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","created":%d,"model":"%s","choices":[{"index":0,"delta":%s,"finish_reason":%s}]}`,
-			chatId, created, parsed.Model, delta, fr)
-		sseLine := []byte("data: " + openaiJSON + "\n")
+		sseLine := append([]byte("data: "), openaiJSON...)
+		sseLine = append(sseLine, '\n')
 
 		if needsTranslate {
 			translated := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, payload, sseLine, &streamParam)
@@ -550,7 +552,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				emitToOut(cliproxyexecutor.StreamChunk{Payload: bytes.Clone(t)})
 			}
 		} else {
-			emitToOut(cliproxyexecutor.StreamChunk{Payload: []byte(openaiJSON)})
+			emitToOut(cliproxyexecutor.StreamChunk{Payload: openaiJSON})
 		}
 	}
 
@@ -595,13 +597,13 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 						thinkingActive = true
 						sendChunkSwitchable(`{"role":"assistant","content":"<think>"}`, "")
 					}
-					sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
+					sendChunkSwitchable(cursorContentDeltaJSON(text), "")
 				} else {
 					if thinkingActive {
 						thinkingActive = false
 						sendChunkSwitchable(`{"content":"</think>"}`, "")
 					}
-					sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
+					sendChunkSwitchable(cursorContentDeltaJSON(text), "")
 				}
 			},
 			func(exec pendingMcpExec) {
@@ -609,11 +611,10 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 					thinkingActive = false
 					sendChunkSwitchable(`{"content":"</think>"}`, "")
 				}
-				toolCallJSON := fmt.Sprintf(`{"tool_calls":[{"index":%d,"id":"%s","type":"function","function":{"name":"%s","arguments":%s}}]}`,
-					toolCallIndex, exec.ToolCallId, exec.ToolName, jsonString(exec.Args))
+				toolCallJSON := cursorToolCallDeltaJSON(toolCallIndex, exec.ToolCallId, exec.ToolName, exec.Args)
 				toolCallIndex++
 				sendChunkSwitchable(toolCallJSON, "")
-				sendChunkSwitchable(`{}`, `"tool_calls"`)
+				sendChunkSwitchable(`{}`, "tool_calls")
 				sendDoneSwitchable()
 
 				// Close current output to end the current HTTP SSE response
@@ -701,23 +702,22 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 		// Include token usage in the final stop chunk
 		inputTok, outputTok := usage.get()
-		stopDelta := fmt.Sprintf(`{},"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}`,
-			inputTok, outputTok, inputTok+outputTok)
-		// Build the stop chunk with usage embedded in the choices array level
-		fr := `"stop"`
-		openaiJSON := fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","created":%d,"model":"%s","choices":[{"index":0,"delta":{},"finish_reason":%s}],"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`,
-			chatId, created, parsed.Model, fr, inputTok, outputTok, inputTok+outputTok)
-		sseLine := []byte("data: " + openaiJSON + "\n")
+		openaiJSON, errMarshal := cursorUsageChunkJSON(chatId, created, parsed.Model, inputTok, outputTok)
+		if errMarshal != nil {
+			log.Warnf("cursor: failed to encode usage chunk: %v", errMarshal)
+			openaiJSON = []byte(`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)
+		}
+		sseLine := append([]byte("data: "), openaiJSON...)
+		sseLine = append(sseLine, '\n')
 		if needsTranslate {
 			translated := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, payload, sseLine, &streamParam)
 			for _, t := range translated {
 				emitToOut(cliproxyexecutor.StreamChunk{Payload: bytes.Clone(t)})
 			}
 		} else {
-			emitToOut(cliproxyexecutor.StreamChunk{Payload: []byte(openaiJSON)})
+			emitToOut(cliproxyexecutor.StreamChunk{Payload: openaiJSON})
 		}
 		sendDoneSwitchable()
-		_ = stopDelta // unused
 
 		// Close whatever output channel is still active
 		outMu.Lock()
@@ -1436,16 +1436,15 @@ func deriveSessionKey(clientKey string, model string, messages []gjson.Result) s
 }
 
 func sseChunk(id string, created int64, model string, delta string, finishReason string) cliproxyexecutor.StreamChunk {
-	fr := "null"
-	if finishReason != "" {
-		fr = finishReason
-	}
 	// Note: the framework's WriteChunk adds "data: " prefix and "\n\n" suffix,
 	// so we only output the raw JSON here.
-	data := fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","created":%d,"model":"%s","choices":[{"index":0,"delta":%s,"finish_reason":%s}]}`,
-		id, created, model, delta, fr)
+	data, err := cursorChunkJSON(id, created, model, json.RawMessage(delta), finishReason)
+	if err != nil {
+		log.Warnf("cursor: failed to encode sse chunk: %v", err)
+		data = []byte(`{"choices":[{"index":0,"delta":{},"finish_reason":null}]}`)
+	}
 	return cliproxyexecutor.StreamChunk{
-		Payload: []byte(data),
+		Payload: data,
 	}
 }
 

--- a/pkg/llmproxy/executor/cursor_executor_test.go
+++ b/pkg/llmproxy/executor/cursor_executor_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCursorCompletionJSONEscapesModelAndContent(t *testing.T) {
+	t.Parallel()
+
+	payload, err := cursorCompletionJSON("chatcmpl-test", 1700000000, `x","pwned":true,"y":"`, `hi "there"`)
+	if err != nil {
+		t.Fatalf("cursorCompletionJSON: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v; payload=%s", err, payload)
+	}
+	if got["model"] != `x","pwned":true,"y":"` {
+		t.Fatalf("model = %q", got["model"])
+	}
+	if _, ok := got["pwned"]; ok {
+		t.Fatalf("payload allowed model to inject top-level field: %s", payload)
+	}
+}
+
+func TestCursorChunkJSONEscapesModelAndFinishReason(t *testing.T) {
+	t.Parallel()
+
+	payload, err := cursorChunkJSON(
+		"chatcmpl-test",
+		1700000000,
+		`x","pwned":true,"y":"`,
+		json.RawMessage(`{"content":"ok"}`),
+		`stop","pwned":true,"x":"`,
+	)
+	if err != nil {
+		t.Fatalf("cursorChunkJSON: %v", err)
+	}
+
+	var got struct {
+		Model   string `json:"model"`
+		Pwned   bool   `json:"pwned"`
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal payload: %v; payload=%s", err, payload)
+	}
+	if got.Model != `x","pwned":true,"y":"` {
+		t.Fatalf("model = %q", got.Model)
+	}
+	if got.Pwned {
+		t.Fatalf("payload allowed model to inject top-level field: %s", payload)
+	}
+	if got.Choices[0].FinishReason != `stop","pwned":true,"x":"` {
+		t.Fatalf("finish_reason = %q", got.Choices[0].FinishReason)
+	}
+}
+
+func TestCursorToolCallDeltaJSONEscapesToolIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	payload := cursorToolCallDeltaJSON(
+		0,
+		`call_1","pwned":true,"x":"`,
+		`tool","pwned":true,"x":"`,
+		`{"ok":true}`,
+	)
+	var got map[string]any
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("unmarshal payload: %v; payload=%s", err, payload)
+	}
+	if _, ok := got["pwned"]; ok {
+		t.Fatalf("payload allowed tool metadata to inject top-level field: %s", payload)
+	}
+}

--- a/pkg/llmproxy/executor/cursor_json.go
+++ b/pkg/llmproxy/executor/cursor_json.go
@@ -1,0 +1,88 @@
+package executor
+
+import "encoding/json"
+
+func cursorCompletionJSON(id string, created int64, model string, content string) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"id":      id,
+		"object":  "chat.completion",
+		"created": created,
+		"model":   model,
+		"choices": []map[string]any{{
+			"index": 0,
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": content,
+			},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]int{"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+	})
+}
+
+func cursorChunkJSON(id string, created int64, model string, delta json.RawMessage, finishReason string) ([]byte, error) {
+	var parsedDelta any
+	if err := json.Unmarshal(delta, &parsedDelta); err != nil {
+		return nil, err
+	}
+	var finish any
+	if finishReason != "" {
+		finish = finishReason
+	}
+	return json.Marshal(map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         parsedDelta,
+			"finish_reason": finish,
+		}},
+	})
+}
+
+func cursorUsageChunkJSON(id string, created int64, model string, inputTokens int64, outputTokens int64) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "stop",
+		}},
+		"usage": map[string]int64{
+			"prompt_tokens":     inputTokens,
+			"completion_tokens": outputTokens,
+			"total_tokens":      inputTokens + outputTokens,
+		},
+	})
+}
+
+func cursorContentDeltaJSON(content string) string {
+	return string(mustCursorMarshal(map[string]any{"content": content}))
+}
+
+func cursorToolCallDeltaJSON(index int, id string, name string, args string) string {
+	return string(mustCursorMarshal(map[string]any{
+		"tool_calls": []map[string]any{{
+			"index": index,
+			"id":    id,
+			"type":  "function",
+			"function": map[string]any{
+				"name":      name,
+				"arguments": args,
+			},
+		}},
+	}))
+}
+
+func mustCursorMarshal(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}


### PR DESCRIPTION
## **User description**
## Summary

Fixes the critical CodeQL findings for unsafe JSON construction in Cursor responses and request-forgery hardening in the management API call path.

## Root Cause

- Cursor completion and streaming responses interpolated model, finish reason, and nearby tool-call metadata into JSON with fmt.Sprintf, leaving string fields vulnerable to malformed JSON injection.
- The management API call endpoint validated the initial URL before building the request, but the client did not revalidate redirected request URLs and the direct transport did not pin the dial target after DNS validation.

## Changes

- Added Cursor JSON helpers that build completion, stream chunk, usage chunk, content delta, and tool-call delta payloads with encoding/json.
- Replaced the flagged Cursor response fmt.Sprintf paths at the reported locations and removed adjacent unsafe tool-call/usage chunk formatting.
- Added a guarded management API HTTP client that validates every outbound request/redirect URL and installs a direct dial guard that resolves, rejects private/local/link-local targets, and dials the validated IP.
- Added focused regression tests for Cursor JSON injection resistance and management API unsafe target rejection.

## Validation

- gofmt on changed Go files
- go test ./pkg/llmproxy/executor/cursor_json.go ./pkg/llmproxy/executor/cursor_executor_test.go
- go test ./pkg/llmproxy/api/handlers/management/api_call_url.go ./pkg/llmproxy/api/handlers/management/api_call_guard.go ./pkg/llmproxy/api/handlers/management/api_call_transport_test.go
- go vet ./pkg/llmproxy/executor/cursor_json.go ./pkg/llmproxy/executor/cursor_executor_test.go
- go vet ./pkg/llmproxy/api/handlers/management/api_call_url.go ./pkg/llmproxy/api/handlers/management/api_call_guard.go ./pkg/llmproxy/api/handlers/management/api_call_transport_test.go

Full package validation remains blocked by existing unrelated compile errors:

- pkg/llmproxy/executor: duplicate assertNoSchemaKeywords, duplicate extractAndRemoveBetas, missing ClaudeHeaderDefaults fields, undefined isClaudeCodeClient/proxyutil, and TranslateStream return-type mismatch.
- pkg/llmproxy/api/handlers/management: duplicate memoryAuthStore plus existing v6/v7 auth manager type mismatches in auth_files tests.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **High Risk**
> Touches security-sensitive outbound request handling and response encoding, adding DNS pinning and redirect validation that could block previously-working destinations or change network behavior. Also changes Cursor streaming/completion JSON construction, which could affect client compatibility if payload shapes differ.
> 
> **Overview**
> Hardens the management `api-call` path against SSRF by introducing a guarded HTTP client that **re-validates URLs on every request and redirect**, and a dial guard that **resolves hosts, rejects private/local/link-local IPs, and dials a validated IP** (reducing DNS-rebinding risk).
> 
> Replaces Cursor executor JSON payload construction (completions, stream chunks, tool-call deltas, usage chunks) from `fmt.Sprintf` string interpolation to `encoding/json` helpers, with added regression tests to ensure untrusted fields can’t inject malformed/top-level JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d88d7d85ee2520eeb24fef2aa225efbbbbf56b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Harden Cursor responses and management API requests against malformed and unsafe URLs**

### What Changed
- Cursor completion and streaming responses now safely encode model names, content, finish reasons, and tool-call data so user-controlled text cannot break the returned JSON.
- Cursor streaming keeps working with safer chunk and usage output, and logs an error if a chunk cannot be encoded instead of sending broken payloads.
- Management API calls now re-check redirected URLs and block requests to unsafe destinations such as localhost, private, link-local, and other restricted targets.
- Outbound management requests now use a guarded dial path that only connects to validated hosts.

### Impact
`✅ Fewer broken Cursor responses`
`✅ Lower risk of JSON injection in streamed output`
`✅ Fewer SSRF-style management API requests`
`✅ Safer redirects to external APIs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=tYSjvJ2HfZqRlRUiTAhI7zE5cm6GY39-IYfQ5XSK4yA&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
