### PR TITLE
[codex] add Pages base to cliproxyapi docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: "Project",
+  description: "Documentation",
+  base: '/cliproxyapi-plusplus/',
+  themeConfig: {
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: 'Journeys', link: '/journeys/' },
+      { text: 'Stories', link: '/stories/' },
+      { text: 'Traceability', link: '/traceability/' },
+    ],
+    sidebar: {
+      '/journeys/': [{
+        text: 'Journeys',
+        items: [
+          { text: 'Overview', link: '/journeys/' },
+          { text: 'Quick Start', link: '/journeys/quick-start' },
+        ]
+      }],
+      '/stories/': [{
+        text: 'Stories',
+        items: [
+          { text: 'Overview', link: '/stories/' },
+          { text: 'Hello World', link: '/stories/hello-world' },
+        ]
+      }],
+      '/traceability/': [{
+        text: 'Traceability',
+        items: [
+          { text: 'Overview', link: '/traceability/' },
+        ]
+      }],
+    }
+  }
+})


### PR DESCRIPTION
Add the GitHub Pages base path to the VitePress docs config so the site resolves correctly under the project subpath.

This is the smallest safe Pages cleanup in the repo. Broader workflow gating cleanup was intentionally left for later.
