### PR TITLE
docs: fix worklog canonical index pointer

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: "Project",
+  description: "Documentation",
+  base: '/cliproxyapi-plusplus/',
+  themeConfig: {
+    nav: [
+      { text: 'Home', link: '/' },
+      { text: 'Journeys', link: '/journeys/' },
+      { text: 'Stories', link: '/stories/' },
+      { text: 'Traceability', link: '/traceability/' },
+    ],
+    sidebar: {
+      '/journeys/': [{
+        text: 'Journeys',
+        items: [
+          { text: 'Overview', link: '/journeys/' },
+          { text: 'Quick Start', link: '/journeys/quick-start' },
+        ]
+      }],
+      '/stories/': [{
+        text: 'Stories',
+        items: [
+          { text: 'Overview', link: '/stories/' },
+          { text: 'Hello World', link: '/stories/hello-world' },
+        ]
+      }],
+      '/traceability/': [{
+        text: 'Traceability',
+        items: [
+          { text: 'Overview', link: '/traceability/' },
+        ]
+      }],
+    }
+  }
+})

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -2,6 +2,8 @@
 
 Active work tracking for **cliproxyapi-plusplus** project.
 
+Canonical worklog index: [docs/worklogs/README.md](./worklogs/README.md)
+
 ---
 
 ## Current Sprint


### PR DESCRIPTION
## **User description**
Point docs/WORKLOG.md at the repo-local worklog index path instead of the nonexistent absolute path.\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes: adds a VitePress site configuration and adjusts a Markdown link; no runtime or data-handling code is affected.
> 
> **Overview**
> Adds a new VitePress configuration (`docs/.vitepress/config.mts`) to define the docs site base path plus top nav and section sidebars for *Journeys*, *Stories*, and *Traceability*.
> 
> Updates `docs/WORKLOG.md` to point the canonical worklog index to the correct repo-local path (`./worklogs/README.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304960a21eb73371d646e296c5ac74d1d11d0430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Set up the docs site for the repository path and point the worklog to the correct index**

### What Changed
- The documentation site now works under the repository subpath, so navigation and page links open correctly when published
- Added top-level navigation and section sidebars for Journeys, Stories, and Traceability
- The worklog now links to the repo-local worklog index instead of an incorrect path

### Impact
`✅ Working docs links on the published site`
`✅ Easier navigation between docs sections`
`✅ Fewer broken worklog references`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=av3EOqJEi870WMCIP8aQp1I-OmOaDkR4xVTbdtyRPSw&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
