### PR TITLE
taskfile: detect repo language

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,17 @@ vars:
   DOCKER_IMAGE: kooshapari/cliproxyapi-plusplus
   TEST_REPORT_DIR: target
   QUALITY_PACKAGES: '{{default "./..." .QUALITY_PACKAGES}}'
+  REPO_LANGUAGE:
+    sh: |
+      if [ -f go.mod ]; then
+        echo go
+      elif [ -f package.json ]; then
+        echo node
+      elif [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+        echo python
+      else
+        echo unknown
+      fi
   GO_FILES:
     sh: find . -name "*.go" | grep -v "vendor"
 
@@ -16,6 +27,11 @@ tasks:
     cmds:
       - task --list
     silent: true
+
+  detect:language:
+    desc: "Print the detected primary repository language"
+    cmds:
+      - echo "{{.REPO_LANGUAGE}}"
 
   check:
     desc: "Canonical full-project check"
@@ -538,6 +554,7 @@ tasks:
       - |
         echo "Checking Go version..."
         go version
+        echo "Detected repository language: {{.REPO_LANGUAGE}}"
         echo "Checking dependencies..."
         if [ ! -f go.mod ]; then echo "❌ go.mod missing"; exit 1; fi
         echo "Checking config template..."


### PR DESCRIPTION
Add a small language-detection helper and task to the existing Taskfile so it can report the repo's primary stack without changing current Go task behavior.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Taskfile-only changes that add informational output and a new helper task without altering build/test logic.
> 
> **Overview**
> Adds a `REPO_LANGUAGE` variable to `Taskfile.yml` that infers the repo’s primary stack (Go/Node/Python/unknown) from common manifest files.
> 
> Introduces `task detect:language` to print the detected language, and updates `task doctor` to report it during environment diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e701d5bec86564c4a09be9d42bf650b74e4f38b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->