### PR TITLE
taskfile: build common Go entrypoints

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,8 @@
 version: '3'
 
 vars:
-  BINARY_NAME: cliproxyapi++
+  SERVER_BINARY: bin/cliproxy-server
+  CLI_BINARY: bin/cliproxyctl
   DOCKER_IMAGE: kooshapari/cliproxyapi-plusplus
   TEST_REPORT_DIR: target
   QUALITY_PACKAGES: '{{default "./..." .QUALITY_PACKAGES}}'
@@ -47,21 +48,24 @@ tasks:
 
   # -- Build & Run --
   build:
-    desc: "Build the cliproxyapi++ binary"
+    desc: "Build the Go server and operational CLI"
     cmds:
-      - go build -o {{.BINARY_NAME}} ./cmd/server
+      - mkdir -p bin
+      - go build -o {{.SERVER_BINARY}} ./cmd/server
+      - go build -o {{.CLI_BINARY}} ./cmd/cliproxyctl
     sources:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
     generates:
-      - "{{.BINARY_NAME}}"
+      - "{{.SERVER_BINARY}}"
+      - "{{.CLI_BINARY}}"
 
   run:
     desc: "Run the proxy locally with default config"
     deps: [build]
     cmds:
-      - ./{{.BINARY_NAME}} --config config.example.yaml
+      - ./{{.SERVER_BINARY}} --config config.example.yaml
 
   preflight:
     desc: "Fail fast if required tooling is missing"


### PR DESCRIPTION
Align the common build task with the detected Go repository layout by building both documented entrypoints under bin/. Keep run and clean pointed at the generated server artifact and build directory.

Validation: task detect:language (go); task --list shows build/test/lint/clean. task build reaches Go compilation but fails on existing executor/config compile errors unrelated to Taskfile wiring.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes local Taskfile build/run targets and output paths, with no runtime code changes.
> 
> **Overview**
> **Build/run Taskfile wiring is updated to match multiple Go entrypoints.** The `build` task now creates `bin/` and compiles both the server (`bin/cliproxy-server`) and an operational CLI (`bin/cliproxyctl`), updating generated artifacts accordingly.
> 
> **Run output is redirected to the new server binary.** The `run` task now executes `./bin/cliproxy-server` (instead of the prior single `cliproxyapi++` binary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d282b294b3763a9a3a5801aa2095bf1ab5fa76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->