### PR TITLE
taskfile: expose common task entrypoints

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,6 +34,17 @@ tasks:
     cmds:
       - echo "{{.REPO_LANGUAGE}}"
 
+  common:
+    desc: "Show detected language and common task entrypoints"
+    cmds:
+      - |
+        echo "Detected language: {{.REPO_LANGUAGE}}"
+        echo "Common tasks:"
+        echo "  task build"
+        echo "  task test"
+        echo "  task lint"
+        echo "  task clean"
+
   check:
     desc: "Canonical full-project check"
     cmds:
@@ -526,9 +537,16 @@ tasks:
         echo "[OK] Installed .git/hooks/pre-commit"
 
   lint:
-    desc: "Run golangci-lint"
+    desc: "Run golangci-lint v2"
     cmds:
-      - golangci-lint run ./...
+      - |
+        if command -v golangci-lint >/dev/null 2>&1 && golangci-lint version | rg -q 'version v2\.'; then
+          golangci-lint run ./...
+          exit 0
+        fi
+
+        echo "[INFO] golangci-lint v2 not found on PATH; running module-pinned v2"
+        go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
 
   tidy:
     desc: "Tidy Go modules"


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Updates the repo’s primary quality gate (`task lint`) to conditionally run a module-fetched golangci-lint v2 when v2 isn’t installed locally, which can change CI/dev lint behavior and introduce dependency-download variability.
> 
> **Overview**
> Adds a new `task common` helper that prints the detected repo language and points contributors to the main entry tasks (`build`, `test`, `lint`, `clean`).
> 
> Updates `task lint` to require **golangci-lint v2**: it now verifies a local v2 binary and otherwise falls back to running the v2 module via `go run github.com/golangci/golangci-lint/v2/...@latest` before linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0172364815763bf99626a91aef416212368b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Show common repo tasks and keep linting working with golangci-lint v2

### What Changed
- Added a `task common` command that shows the detected language and points contributors to the main build, test, lint, and clean tasks
- Linting now uses golangci-lint v2; if that version is not installed locally, it runs the v2 tool through Go instead of stopping
- The lint task label now clearly reflects the v2 requirement

### Impact
`✅ Easier onboarding for new contributors`
`✅ Fewer lint failures on machines without golangci-lint v2`
`✅ More consistent lint runs across local and CI setups`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=LI_DTd0_XDEMdmrW7C6FItmGxUcdZ_0D6fpf6cMd48Q&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
