### PR TITLE
taskfile: isolate Go build cache

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,7 @@ vars:
   CLI_BINARY: bin/cliproxyctl
   DOCKER_IMAGE: kooshapari/cliproxyapi-plusplus
   TEST_REPORT_DIR: target
+  GO_CACHE_DIR: '{{.ROOT_DIR}}/.cache/go-build'
   QUALITY_PACKAGES: '{{default "./..." .QUALITY_PACKAGES}}'
   REPO_LANGUAGE:
     sh: |
@@ -22,6 +23,9 @@ vars:
       fi
   GO_FILES:
     sh: find . -name "*.go" | grep -v "vendor"
+
+env:
+  GOCACHE: '{{.GO_CACHE_DIR}}'
 
 tasks:
   default:
@@ -66,7 +70,7 @@ tasks:
   build:
     desc: "Build the Go server and operational CLI"
     cmds:
-      - mkdir -p bin
+      - mkdir -p bin {{.GO_CACHE_DIR}}
       - go build -o {{.SERVER_BINARY}} ./cmd/server
       - go build -o {{.CLI_BINARY}} ./cmd/cliproxyctl
     sources:
@@ -87,6 +91,7 @@ tasks:
     desc: "Fail fast if required tooling is missing"
     cmds:
       - |
+        mkdir -p "{{.GO_CACHE_DIR}}"
         command -v go >/dev/null 2>&1 || { echo "[FAIL] go is required"; exit 1; }
         command -v task >/dev/null 2>&1 || { echo "[FAIL] task is required"; exit 1; }
         command -v git >/dev/null 2>&1 || { echo "[FAIL] git is required"; exit 1; }
@@ -144,11 +149,16 @@ tasks:
       - go test -v ./...
 
   clean:
-    desc: "Remove local Go build artifacts, Go lint cache, and Task cache"
+    desc: "Remove local Go build artifacts, Go caches, Go lint cache, and Task cache"
     cmds:
       - |
+        go clean -cache -testcache || true
         rm -f cliproxyapi++ cliproxy-server coverage.out
-        rm -rf target bin .task .cache/go-build
+        for path in target bin .task .cache/go-build; do
+          if [ -e "$path" ]; then
+            rm -rf "$path" || { sleep 1; rm -rf "$path"; }
+          fi
+        done
         echo "[OK] Removed local build artifacts"
 
   quality:fmt:


### PR DESCRIPTION
## **User description**
Use a repo-local Go build cache for Taskfile commands so common build, test, lint, and clean tasks avoid corrupt or racing shared cache state. Harden clean to clear the configured cache before removing local artifacts.\n\nCo-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Taskfile-only changes that adjust local build/test caching and cleanup behavior without touching runtime application code.
> 
> **Overview**
> Configures Task tasks to use a **repo-local Go build cache** by introducing `GO_CACHE_DIR` and setting `GOCACHE` globally, and ensures the cache directory exists during `build` and `preflight`.
> 
> Hardens `clean` to also clear Go build/test caches (`go clean -cache -testcache`) and to more robustly remove local artifact/cache directories with a retry on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda407bb5c6ac1a3f4dbb02dec218d0b57a0567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Use a repo-local Go cache and clean it more reliably for Taskfile commands**

### What Changed
- Taskfile commands now use a cache inside the repository instead of a shared Go cache
- Build and preflight create the cache folder before running, so setup is less likely to fail
- Clean now removes Go’s build and test cache, and retries stuck local folder removals once before giving up

### Impact
`✅ Fewer build and test cache conflicts`
`✅ More reliable local Taskfile runs`
`✅ Cleaner project reset after builds`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ikO8HecCM6unWk0lB0dp9MfiGu6hBI8ILIartHsdySA&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
