### PR TITLE
taskfile: make build independent of checksum cache

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,13 +74,6 @@ tasks:
       - mkdir -p bin {{.GO_CACHE_DIR}}
       - go build -o {{.SERVER_BINARY}} ./cmd/server
       - go build -o {{.CLI_BINARY}} ./cmd/cliproxyctl
-    sources:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-    generates:
-      - "{{.SERVER_BINARY}}"
-      - "{{.CLI_BINARY}}"
 
   run:
     desc: "Run the proxy locally with default config"


### PR DESCRIPTION
## **User description**
The common build task should run from a fresh checkout even when Task's local checksum cache directory has not been created yet. Removing the source/generate metadata keeps the same Go build commands while avoiding pre-command cache failures after cleanups.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes Taskfile build metadata, leaving the actual `go build` commands unchanged; impact is limited to Task's incremental build/checksum behavior.
> 
> **Overview**
> Makes `task build` runnable from a fresh checkout by removing the `sources`/`generates` metadata from the `build` task, avoiding failures when Task's checksum/cache state is missing.
> 
> The underlying build commands (creating `bin` and compiling the server/CLI) are unchanged; only Task’s change-detection/incremental behavior is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601e6ca2c98eb577ba99f963ed6ccdd2644fb339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Make `task build` run from a fresh checkout

### What Changed
- `task build` no longer depends on Task’s checksum cache being present first
- Builds still create the same server and CLI binaries in `bin`
- Running the app locally through the build task keeps the same output, but avoids cache-related failures after cleanup

### Impact
`✅ Fresh-checkout builds`
`✅ Fewer build failures after cleanup`
`✅ Reliable local startup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Yz_cXE_4dZXRuP1RBtiv_ouDQ73XKLAga_SLdbqruAY&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
