### PR TITLE
docs: add work-state header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Work state:** ACTIVE · **Progress:** `███████░░░ 70%`
+> CLIProxyAPI++ — multi-provider LLM proxy fork. Builds + CI workflows repaired (25 files). Residual: pre-existing Go test failures surfaced now that CI runs. · updated 2026-06-02
+
 # cliproxyapi-plusplus
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKooshaPari%2Fcliproxyapi-plusplus.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FKooshaPari%2Fcliproxyapi-plusplus?ref=badge_shield)
 [![AI Slop Inside](https://sladge.net/badge.svg)](https://sladge.net)


### PR DESCRIPTION
Adds the org-standard work-state header (state + 10-block progress bar + focus line + date) to the top of the README, per the org-wide README work-state convention. State/percent set honestly from the dom-cli-ax coherence audit. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation with no effect on application behavior or deployment.
> 
> **Overview**
> Adds the org-standard **work-state** block at the top of `README.md`: **ACTIVE** status, a **70%** progress bar, a one-line focus summary (builds/CI repaired, residual Go test failures), and **updated 2026-06-02**.
> 
> Documentation-only; no runtime, config, or CI workflow changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda1daf9263f6d9f62ea763366f8519a1412597a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->