### PR TITLE
Wave H3: vibeproxy client absorption doc

### DIFF
--- a/VIBEPROXY_ABSORPTION.md
+++ b/VIBEPROXY_ABSORPTION.md
@@ -1,0 +1,17 @@
+# vibeproxy client absorption (Wave H3)
+
+**Canonical proxy plane:** cliproxyapi-plusplus  
+**Deprecated client:** [vibeproxy](https://github.com/KooshaPari/vibeproxy) — macOS menu-bar routing via CLIProxyAPIPlus
+
+## Absorption path
+
+1. Document vibeproxy subscription-routing UX in cliproxy++ operator docs
+2. Optional `client/vibeproxy/` subtree or separate Swift package linked from this repo
+3. Registry disposition: vibeproxy `fsm: done` → cliproxyapi-plusplus
+
+## Branches to reconcile (vibeproxy)
+
+- `merge-upstream-2026-05-28`
+- `chore/vibeproxy-merge-origin-main`
+
+Do not maintain parallel macOS client repos after parity.


### PR DESCRIPTION
## **User description**
## Summary
- Add VIBEPROXY_ABSORPTION.md at repo root
- Documents absorption of deprecated vibeproxy macOS client into cliproxy++ proxy plane

## Test plan
- [x] Doc only

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Document the vibeproxy client absorption path**

### What Changed
- Adds a top-level document that marks vibeproxy as the deprecated macOS client and identifies cliproxyapi-plusplus as the canonical proxy plane
- Describes the intended path for moving vibeproxy routing and subscription guidance into cliproxy++ docs, with an optional shared client package
- Lists the branches that need to be reconciled and states that parallel macOS client repos should not be kept after parity

### Impact
`✅ Clearer migration path for macOS client users`
`✅ Fewer duplicate client repos to maintain`
`✅ Easier handoff from vibeproxy to cliproxy++`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
