### PR TITLE
fix(smoke): guard syscall.Umask for non-Unix builds

### DIFF
--- a/pkg/llmproxy/api/unixsock/listener.go
+++ b/pkg/llmproxy/api/unixsock/listener.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -91,7 +90,7 @@ func (l *Listener) Serve(handler http.Handler) error {
 	}
 
 	// Actually create the socket
-	syscall.Umask(0) // Use exact permissions
+	clearUmask() // Use exact permissions on Unix
 	ln, err := net.Listen("unix", l.config.Path)
 	if err != nil {
 		return fmt.Errorf("failed to listen on unix socket: %w", err)

--- a/pkg/llmproxy/api/unixsock/umask_other.go
+++ b/pkg/llmproxy/api/unixsock/umask_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package unixsock
+
+func clearUmask() {}

--- a/pkg/llmproxy/api/unixsock/umask_unix.go
+++ b/pkg/llmproxy/api/unixsock/umask_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package unixsock
+
+import "syscall"
+
+func clearUmask() {
+	syscall.Umask(0)
+}


### PR DESCRIPTION
## **User description**
## Summary
- Split syscall.Umask into unix-tagged helper so go build ./... works on Windows

## Context
H9 gateway smoke runs locally on Windows; unixsock listener failed with undefined syscall.Umask.

## Test plan
- [x] go build ./... on Windows
- [ ] go build ./... on Linux unchanged

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Allow Unix socket smoke tests to build on Windows**

### What Changed
- Unix socket setup now skips the permission reset on non-Unix builds, so `go build ./...` works on Windows
- On Unix systems, the socket still gets created with the expected permissions

### Impact
`✅ Windows smoke builds succeed`
`✅ Fewer local build failures on non-Unix machines`
`✅ Unix socket permissions stay correct on Unix`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
