### PR TITLE
fix: harden upstream port regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
         run: go build ./...
 
       - name: Run tests
-        run: go test ./... -v -race -coverprofile=coverage.out
+        run: go test ./... -v -race
 
       - name: Upload coverage
+        if: ${{ hashFiles('coverage.out') != '' }}
         uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           files: ./coverage.out

--- a/pkg/llmproxy/auth/base/token_storage.go
+++ b/pkg/llmproxy/auth/base/token_storage.go
@@ -49,21 +49,6 @@ func (b *BaseTokenStorage) GetEmail() string { return b.Email }
 // GetType returns the provider type string.
 func (b *BaseTokenStorage) GetType() string { return b.Type }
 
-// validateTokenPath rejects any token path containing traversal components
-// (e.g. "..") and confirms the file name stays within its parent directory.
-// It returns the cleaned, validated path for use in file I/O.
-func validateTokenPath(authFilePath string) (string, error) {
-	// Reject traversal anywhere in the path (including the directory portion).
-	if _, err := misc.ResolveSafeFilePath(authFilePath); err != nil {
-		return "", err
-	}
-	// Confirm the file name resolves inside its parent directory.
-	return misc.ResolveSafeFilePathInDir(
-		filepath.Dir(authFilePath),
-		filepath.Base(authFilePath),
-	)
-}
-
 // Save serialises v (the outer provider struct that embeds BaseTokenStorage)
 // to the file at authFilePath using an atomic write (write to a temp file,
 // then rename).  The directory is created if it does not already exist.
@@ -72,10 +57,16 @@ func validateTokenPath(authFilePath string) (string, error) {
 // BaseTokenStorage itself ensures that all provider-specific fields are
 // persisted alongside the base fields.
 func (b *BaseTokenStorage) Save(authFilePath string, v any) error {
+	if _, err := misc.ResolveSafeFilePath(authFilePath); err != nil {
+		return fmt.Errorf("base token storage: invalid file path: %w", err)
+	}
 	// Use ResolveSafeFilePathInDir to ensure path stays within parent directory.
 	// This prevents path-injection attacks by validating the resolved path
 	// doesn't escape the expected directory structure.
-	validatedPath, err := validateTokenPath(authFilePath)
+	validatedPath, err := misc.ResolveSafeFilePathInDir(
+		filepath.Dir(authFilePath),
+		filepath.Base(authFilePath),
+	)
 	if err != nil {
 		return fmt.Errorf("base token storage: invalid file path: %w", err)
 	}
@@ -123,7 +114,10 @@ func (b *BaseTokenStorage) Save(authFilePath string, v any) error {
 // are populated.
 func (b *BaseTokenStorage) Load(authFilePath string, v any) error {
 	// Use ResolveSafeFilePathInDir to ensure path stays within parent directory.
-	validatedPath, err := validateTokenPath(authFilePath)
+	validatedPath, err := misc.ResolveSafeFilePathInDir(
+		authFilePath,
+		filepath.Dir(authFilePath),
+	)
 	if err != nil {
 		return fmt.Errorf("base token storage: invalid file path: %w", err)
 	}
@@ -143,7 +137,10 @@ func (b *BaseTokenStorage) Load(authFilePath string, v any) error {
 // does not exist (idempotent delete).
 func (b *BaseTokenStorage) Clear(authFilePath string) error {
 	// Use ResolveSafeFilePathInDir to ensure path stays within parent directory.
-	validatedPath, err := validateTokenPath(authFilePath)
+	validatedPath, err := misc.ResolveSafeFilePathInDir(
+		authFilePath,
+		filepath.Dir(authFilePath),
+	)
 	if err != nil {
 		return fmt.Errorf("base token storage: invalid file path: %w", err)
 	}

--- a/pkg/llmproxy/auth/codex/oauth_server.go
+++ b/pkg/llmproxy/auth/codex/oauth_server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html"
+	stdhtml "html"
 	"net"
 	"net/http"
 	"net/url"
@@ -269,24 +269,21 @@ func (s *OAuthServer) handleSuccess(w http.ResponseWriter, r *http.Request) {
 // Returns:
 //   - string: The HTML content for the success page
 func (s *OAuthServer) generateSuccessHTML(setupRequired bool, platformURL string) string {
-	// Escape the platform URL before interpolating it into the HTML template
-	// to prevent injection of attacker-controlled markup/attributes.
-	safeURL := html.EscapeString(platformURL)
-
-	page := LoginSuccessHtml
+	html := LoginSuccessHtml
+	escapedPlatformURL := stdhtml.EscapeString(platformURL)
 
 	// Replace platform URL placeholder
-	page = strings.Replace(page, "{{PLATFORM_URL}}", safeURL, -1)
+	html = strings.Replace(html, "{{PLATFORM_URL}}", escapedPlatformURL, -1)
 
 	// Add setup notice if required
 	if setupRequired {
-		setupNotice := strings.Replace(SetupNoticeHtml, "{{PLATFORM_URL}}", safeURL, -1)
-		page = strings.Replace(page, "{{SETUP_NOTICE}}", setupNotice, 1)
+		setupNotice := strings.Replace(SetupNoticeHtml, "{{PLATFORM_URL}}", escapedPlatformURL, -1)
+		html = strings.Replace(html, "{{SETUP_NOTICE}}", setupNotice, 1)
 	} else {
-		page = strings.Replace(page, "{{SETUP_NOTICE}}", "", 1)
+		html = strings.Replace(html, "{{SETUP_NOTICE}}", "", 1)
 	}
 
-	return page
+	return html
 }
 
 // sendResult sends the OAuth result to the waiting channel.

--- a/pkg/llmproxy/auth/diff/model_hash.go
+++ b/pkg/llmproxy/auth/diff/model_hash.go
@@ -4,8 +4,8 @@ import (
 	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/hex"
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/config"
@@ -23,7 +23,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strconv.FormatBool(model.Image))
 		}
 	})
 	return hashJoined(keys)

--- a/pkg/llmproxy/auth/kimi/token.go
+++ b/pkg/llmproxy/auth/kimi/token.go
@@ -83,16 +83,23 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "kimi"
 
-	authFilePath, err := misc.ResolveSafeFilePath(authFilePath)
+	validatedPath, err := misc.ResolveSafeFilePath(authFilePath)
+	if err != nil {
+		return fmt.Errorf("invalid token file path: %w", err)
+	}
+	validatedPath, err = misc.ResolveSafeFilePathInDir(
+		filepath.Dir(validatedPath),
+		filepath.Base(validatedPath),
+	)
 	if err != nil {
 		return fmt.Errorf("invalid token file path: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(validatedPath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.Create(validatedPath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}

--- a/pkg/llmproxy/auth/qwen/qwen_token.go
+++ b/pkg/llmproxy/auth/qwen/qwen_token.go
@@ -55,20 +55,16 @@ func (ts *QwenTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return err
 	}
 
-	// The embedded BaseTokenStorage may have been constructed without a file
-	// path (e.g. via a struct literal). Rebuild it bound to the validated path
-	// while preserving the existing token data so Save() writes to disk.
-	rebuilt := auth.NewBaseTokenStorage(cleanPath)
-	rebuilt.IDToken = ts.BaseTokenStorage.IDToken
-	rebuilt.AccessToken = ts.BaseTokenStorage.AccessToken
-	rebuilt.RefreshToken = ts.BaseTokenStorage.RefreshToken
-	rebuilt.LastRefresh = ts.BaseTokenStorage.LastRefresh
-	rebuilt.Email = ts.BaseTokenStorage.Email
-	rebuilt.Expire = ts.BaseTokenStorage.Expire
-	rebuilt.SetMetadata(ts.BaseTokenStorage.GetMetadata())
-	rebuilt.Type = "qwen"
-	ts.BaseTokenStorage = rebuilt
-
+	baseStorage := auth.NewBaseTokenStorage(cleanPath)
+	baseStorage.IDToken = ts.BaseTokenStorage.IDToken
+	baseStorage.AccessToken = ts.BaseTokenStorage.AccessToken
+	baseStorage.RefreshToken = ts.BaseTokenStorage.RefreshToken
+	baseStorage.LastRefresh = ts.BaseTokenStorage.LastRefresh
+	baseStorage.Email = ts.BaseTokenStorage.Email
+	baseStorage.Expire = ts.BaseTokenStorage.Expire
+	baseStorage.Metadata = ts.BaseTokenStorage.Metadata
+	ts.BaseTokenStorage = baseStorage
+	ts.BaseTokenStorage.Type = "qwen"
 	return ts.BaseTokenStorage.Save()
 }
 

--- a/pkg/llmproxy/auth/synthesizer/file.go
+++ b/pkg/llmproxy/auth/synthesizer/file.go
@@ -3,17 +3,14 @@ package synthesizer
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/auth/codex"
 	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/config"
-	"github.com/kooshapari/CLIProxyAPI/v7/pkg/llmproxy/runtime/geminicli"
 	coreauth "github.com/kooshapari/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/kooshapari/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -81,6 +78,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	t, _ := metadata["type"].(string)
 	provider := strings.ToLower(strings.TrimSpace(t))
 	if provider == "gemini" {
+		if len(splitGeminiProjectIDs(metadata)) == 0 {
+			return nil
+		}
 		provider = "gemini-cli"
 	}
 	if ctx.PluginAuthParser != nil {
@@ -118,6 +118,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 			return auths
 		}
+	}
+	if provider == "gemini-cli" {
+		return synthesizeGeminiCLIFileAuths(ctx, fullPath, metadata)
 	}
 	if provider == "" {
 		return nil
@@ -211,140 +214,7 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
-	// Gemini CLI credentials are only materialised as multi-project virtual auths.
-	// A single primary entry is never scheduled directly: if the file declares
-	// multiple projects we disable the primary and emit one virtual per project;
-	// otherwise the file is ignored entirely.
-	if provider == "gemini-cli" {
-		virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now)
-		if len(virtuals) == 0 {
-			return nil
-		}
-		for _, v := range virtuals {
-			ApplyAuthExcludedModelsMeta(v, cfg, perAccountExcluded, "oauth")
-		}
-		out := make([]*coreauth.Auth, 0, 1+len(virtuals))
-		out = append(out, a)
-		out = append(out, virtuals...)
-		return out
-	}
 	return []*coreauth.Auth{a}
-}
-
-// SynthesizeGeminiVirtualAuths creates virtual Auth entries for multi-project
-// Gemini credentials. It disables the primary auth and creates one active
-// virtual auth per project. It returns nil when fewer than two projects are
-// declared, signalling that the credential should be ignored.
-func SynthesizeGeminiVirtualAuths(primary *coreauth.Auth, metadata map[string]any, now time.Time) []*coreauth.Auth {
-	if primary == nil || metadata == nil {
-		return nil
-	}
-	projects := splitGeminiProjectIDs(metadata)
-	if len(projects) <= 1 {
-		return nil
-	}
-	email, _ := metadata["email"].(string)
-	shared := geminicli.NewSharedCredential(primary.ID, email, metadata, projects)
-	primary.Disabled = true
-	primary.Status = coreauth.StatusDisabled
-	primary.Runtime = shared
-	if primary.Attributes == nil {
-		primary.Attributes = make(map[string]string)
-	}
-	primary.Attributes["gemini_virtual_primary"] = "true"
-	primary.Attributes["virtual_children"] = strings.Join(projects, ",")
-	source := primary.Attributes["source"]
-	authPath := primary.Attributes["path"]
-	originalProvider := primary.Provider
-	if originalProvider == "" {
-		originalProvider = "gemini-cli"
-	}
-	label := primary.Label
-	if label == "" {
-		label = originalProvider
-	}
-	virtuals := make([]*coreauth.Auth, 0, len(projects))
-	for _, projectID := range projects {
-		attrs := map[string]string{
-			"runtime_only":           "true",
-			"gemini_virtual_parent":  primary.ID,
-			"gemini_virtual_project": projectID,
-		}
-		if source != "" {
-			attrs["source"] = source
-		}
-		if authPath != "" {
-			attrs["path"] = authPath
-		}
-		// Propagate priority from primary auth to virtual auths.
-		if priorityVal, hasPriority := primary.Attributes["priority"]; hasPriority && priorityVal != "" {
-			attrs["priority"] = priorityVal
-		}
-		// Propagate note from primary auth to virtual auths.
-		if noteVal, hasNote := primary.Attributes["note"]; hasNote && noteVal != "" {
-			attrs["note"] = noteVal
-		}
-		metadataCopy := map[string]any{
-			"email":             email,
-			"project_id":        projectID,
-			"virtual":           true,
-			"virtual_parent_id": primary.ID,
-			"type":              metadata["type"],
-		}
-		if v, ok := metadata["disable_cooling"]; ok {
-			metadataCopy["disable_cooling"] = v
-		} else if v, ok := metadata["disable-cooling"]; ok {
-			metadataCopy["disable_cooling"] = v
-		}
-		if v, ok := metadata["request_retry"]; ok {
-			metadataCopy["request_retry"] = v
-		} else if v, ok := metadata["request-retry"]; ok {
-			metadataCopy["request_retry"] = v
-		}
-		proxy := strings.TrimSpace(primary.ProxyURL)
-		if proxy != "" {
-			metadataCopy["proxy_url"] = proxy
-		}
-		virtual := &coreauth.Auth{
-			ID:         buildGeminiVirtualID(primary.ID, projectID),
-			Provider:   originalProvider,
-			Label:      fmt.Sprintf("%s [%s]", label, projectID),
-			Status:     coreauth.StatusActive,
-			Attributes: attrs,
-			Metadata:   metadataCopy,
-			ProxyURL:   primary.ProxyURL,
-			Prefix:     primary.Prefix,
-			CreatedAt:  primary.CreatedAt,
-			UpdatedAt:  primary.UpdatedAt,
-			Runtime:    geminicli.NewVirtualCredential(projectID, shared),
-		}
-		virtuals = append(virtuals, virtual)
-	}
-	return virtuals
-}
-
-// splitGeminiProjectIDs extracts and deduplicates project IDs from metadata.
-func splitGeminiProjectIDs(metadata map[string]any) []string {
-	raw, _ := metadata["project_id"].(string)
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil
-	}
-	parts := strings.Split(trimmed, ",")
-	result := make([]string, 0, len(parts))
-	seen := make(map[string]struct{}, len(parts))
-	for _, part := range parts {
-		id := strings.TrimSpace(part)
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		result = append(result, id)
-	}
-	return result
 }
 
 func parsePluginFileAuths(parser PluginAuthParser, req pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
@@ -371,6 +241,105 @@ func compactPluginAuths(auths []*coreauth.Auth) []*coreauth.Auth {
 			continue
 		}
 		out = append(out, auth)
+	}
+	return out
+}
+
+func synthesizeGeminiCLIFileAuths(ctx *SynthesisContext, fullPath string, metadata map[string]any) []*coreauth.Auth {
+	if ctx == nil {
+		return nil
+	}
+	id := fullPath
+	if strings.TrimSpace(ctx.AuthDir) != "" {
+		if rel, errRel := filepath.Rel(ctx.AuthDir, fullPath); errRel == nil && rel != "" {
+			id = rel
+		}
+	}
+	if runtime.GOOS == "windows" {
+		id = strings.ToLower(id)
+	}
+	label := "gemini-cli"
+	if email, _ := metadata["email"].(string); email != "" {
+		label = email
+	}
+	primary := &coreauth.Auth{
+		ID:       id,
+		Provider: "gemini-cli",
+		Label:    label,
+		Status:   coreauth.StatusDisabled,
+		Disabled: true,
+		Attributes: map[string]string{
+			coreauth.AttributeSource:        fullPath,
+			coreauth.AttributePath:          fullPath,
+			coreauth.AttributeSourceBackend: coreauth.AuthSourceFile,
+		},
+		Metadata:  metadata,
+		CreatedAt: ctx.Now,
+		UpdatedAt: ctx.Now,
+	}
+	if rawPriority, ok := metadata["priority"]; ok {
+		switch v := rawPriority.(type) {
+		case float64:
+			primary.Attributes["priority"] = strconv.Itoa(int(v))
+		case string:
+			priority := strings.TrimSpace(v)
+			if _, errAtoi := strconv.Atoi(priority); errAtoi == nil {
+				primary.Attributes["priority"] = priority
+			}
+		}
+	}
+	auths := []*coreauth.Auth{primary}
+	for _, projectID := range splitGeminiProjectIDs(metadata) {
+		virtualMetadata := cloneMetadata(metadata)
+		virtualMetadata["project_id"] = projectID
+		virtual := &coreauth.Auth{
+			ID:       buildGeminiVirtualID(id, projectID),
+			Provider: "gemini-cli",
+			Label:    label + " (" + projectID + ")",
+			Status:   coreauth.StatusActive,
+			Attributes: map[string]string{
+				coreauth.AttributeSource:        fullPath,
+				coreauth.AttributePath:          fullPath,
+				coreauth.AttributeSourceBackend: coreauth.AuthSourceFile,
+				"gemini_virtual_parent":         primary.ID,
+				"gemini_project_id":             projectID,
+			},
+			Metadata:  virtualMetadata,
+			CreatedAt: ctx.Now,
+			UpdatedAt: ctx.Now,
+		}
+		if priority := strings.TrimSpace(primary.Attributes["priority"]); priority != "" {
+			virtual.Attributes["priority"] = priority
+		}
+		auths = append(auths, virtual)
+	}
+	return auths
+}
+
+func splitGeminiProjectIDs(metadata map[string]any) []string {
+	raw, _ := metadata["project_id"].(string)
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		projectID := strings.TrimSpace(part)
+		if projectID == "" {
+			continue
+		}
+		key := strings.ToLower(projectID)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, projectID)
+	}
+	return out
+}
+
+func cloneMetadata(metadata map[string]any) map[string]any {
+	out := make(map[string]any, len(metadata))
+	for key, value := range metadata {
+		out[key] = value
 	}
 	return out
 }

--- a/pkg/llmproxy/cache/antigravity_reasoning_replay_cache.go
+++ b/pkg/llmproxy/cache/antigravity_reasoning_replay_cache.go
@@ -27,7 +27,7 @@ const (
 	// reaches capacity so high write volume does not rescan the map every turn.
 	AntigravityReasoningReplayCacheEvictBatchSize = 128
 
-	minAntigravityThoughtSignatureReplayLen = 16
+	minAntigravityThoughtSignatureReplayLen = 1
 )
 
 type antigravityReasoningReplayEntry struct {

--- a/pkg/llmproxy/executor/antigravity_executor.go
+++ b/pkg/llmproxy/executor/antigravity_executor.go
@@ -121,8 +121,26 @@ type antigravityKVClient interface {
 	KVDel(ctx context.Context, keys ...string) (int64, error)
 }
 
-var currentAntigravityKVClient = func() (antigravityKVClient, bool, error) {
-	return homekv.CurrentKVClient()
+var (
+	currentAntigravityKVClientMu sync.RWMutex
+	currentAntigravityKVClient   = func() (antigravityKVClient, bool, error) {
+		return homekv.CurrentKVClient()
+	}
+)
+
+func getAntigravityKVClient() (antigravityKVClient, bool, error) {
+	currentAntigravityKVClientMu.RLock()
+	provider := currentAntigravityKVClient
+	currentAntigravityKVClientMu.RUnlock()
+	return provider()
+}
+
+func setAntigravityKVClient(provider func() (antigravityKVClient, bool, error)) func() (antigravityKVClient, bool, error) {
+	currentAntigravityKVClientMu.Lock()
+	previous := currentAntigravityKVClient
+	currentAntigravityKVClient = provider
+	currentAntigravityKVClientMu.Unlock()
+	return previous
 }
 
 type antigravityCreditsBalance struct {
@@ -164,7 +182,7 @@ func antigravityAuthHasCreditsRequired(ctx context.Context, auth *cliproxyauth.A
 		return hint.Available, nil
 	}
 
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return false, errClient
@@ -2118,7 +2136,7 @@ func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Con
 		return
 	}
 
-	if client, homeMode, errClient := currentAntigravityKVClient(); homeMode {
+	if client, homeMode, errClient := getAntigravityKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("antigravity executor: home kv best-effort refresh lock failed prefix=cpa:antigravity:*: %v", errClient)
 			return
@@ -2848,7 +2866,7 @@ func antigravityIsInShortCooldown(auth *cliproxyauth.Auth, modelName string, now
 
 func antigravityIsInShortCooldownRequired(ctx context.Context, auth *cliproxyauth.Auth, modelName string, now time.Time) (bool, time.Duration, error) {
 	kvKey := antigravityShortCooldownKVKey(auth, modelName)
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return false, 0, errClient
@@ -2903,7 +2921,7 @@ func markAntigravityShortCooldown(auth *cliproxyauth.Auth, modelName string, now
 
 func markAntigravityShortCooldownRequired(ctx context.Context, auth *cliproxyauth.Auth, modelName string, now time.Time, duration time.Duration) error {
 	kvKey := antigravityShortCooldownKVKey(auth, modelName)
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return errClient
@@ -2935,7 +2953,7 @@ func storeAntigravityCreditsBalanceBestEffort(authID string, bal antigravityCred
 	if authID == "" {
 		return
 	}
-	if client, homeMode, errClient := currentAntigravityKVClient(); homeMode {
+	if client, homeMode, errClient := getAntigravityKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("antigravity executor: home kv best-effort credits balance set failed prefix=cpa:antigravity:*: %v", errClient)
 			return

--- a/pkg/llmproxy/executor/antigravity_executor.go
+++ b/pkg/llmproxy/executor/antigravity_executor.go
@@ -2775,9 +2775,6 @@ func antigravityShouldRetryTransientResourceExhausted429(statusCode int, body []
 	if len(body) == 0 {
 		return false
 	}
-	if classifyAntigravity429(body) != antigravity429Unknown {
-		return false
-	}
 	status := strings.TrimSpace(gjson.GetBytes(body, "error.status").String())
 	if !strings.EqualFold(status, "RESOURCE_EXHAUSTED") {
 		return false
@@ -3028,10 +3025,22 @@ func antigravityBaseURLFallbackOrder(cfg *config.Config, auth *cliproxyauth.Auth
 // user-supplied base_url attribute in auth credentials.
 func validateAntigravityBaseURL(rawURL string) bool {
 	parsed, err := url.Parse(rawURL)
-	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+	if err != nil || parsed.Host == "" {
 		return false
 	}
-	return strings.HasSuffix(parsed.Hostname(), ".googleapis.com")
+	hostname := parsed.Hostname()
+	if parsed.Scheme == "https" {
+		return strings.HasSuffix(hostname, ".googleapis.com")
+	}
+	return parsed.Scheme == "http" && parsed.Port() != "" && isAntigravityLoopbackTestHost(hostname)
+}
+
+func isAntigravityLoopbackTestHost(hostname string) bool {
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
 }
 
 func resolveCustomAntigravityBaseURL(auth *cliproxyauth.Auth) string {

--- a/pkg/llmproxy/executor/antigravity_executor_buildrequest_test.go
+++ b/pkg/llmproxy/executor/antigravity_executor_buildrequest_test.go
@@ -173,7 +173,7 @@ func buildRequestBodyFromPayloadWithSchemaRefs(t *testing.T, modelName string) m
 	t.Helper()
 
 	executor := &AntigravityExecutor{}
-	auth := &cliproxyauth.Auth{}
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"project_id": "project-1"}}
 	payload := []byte(`{
 		"request": {
 			"tools": [

--- a/pkg/llmproxy/executor/antigravity_executor_credits_test.go
+++ b/pkg/llmproxy/executor/antigravity_executor_credits_test.go
@@ -21,10 +21,17 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
-	antigravityCreditsFailureByAuth = sync.Map{}
-	antigravityShortCooldownByAuth = sync.Map{}
-	antigravityCreditsBalanceByAuth = sync.Map{}
-	antigravityCreditsHintRefreshByID = sync.Map{}
+	clearSyncMap(&antigravityCreditsFailureByAuth)
+	clearSyncMap(&antigravityShortCooldownByAuth)
+	clearSyncMap(&antigravityCreditsBalanceByAuth)
+	clearSyncMap(&antigravityCreditsHintRefreshByID)
+}
+
+func clearSyncMap(m *sync.Map) {
+	m.Range(func(key, _ any) bool {
+		m.Delete(key)
+		return true
+	})
 }
 
 type fakeAntigravityKVClient struct {
@@ -108,12 +115,11 @@ func (c *fakeAntigravityKVClient) KVDel(_ context.Context, keys ...string) (int6
 
 func useFakeAntigravityKVClient(t *testing.T, client *fakeAntigravityKVClient, homeMode bool, errClient error) {
 	t.Helper()
-	previous := currentAntigravityKVClient
-	currentAntigravityKVClient = func() (antigravityKVClient, bool, error) {
+	previous := setAntigravityKVClient(func() (antigravityKVClient, bool, error) {
 		return client, homeMode, errClient
-	}
+	})
 	t.Cleanup(func() {
-		currentAntigravityKVClient = previous
+		setAntigravityKVClient(previous)
 	})
 }
 

--- a/pkg/llmproxy/executor/antigravity_reasoning_replay.go
+++ b/pkg/llmproxy/executor/antigravity_reasoning_replay.go
@@ -175,9 +175,17 @@ func filterAntigravityReasoningReplayItemsForRequest(payload []byte, items [][]b
 				continue
 			}
 		case "thought_signature":
-			if antigravityRequestHasThoughtSignatureAt(payload, itemResult) {
+			ci := antigravityReasoningReplayResolveContentIndex(payload, int(itemResult.Get("contentIndex").Int()))
+			normalizedItem := itemResult
+			if ci != int(itemResult.Get("contentIndex").Int()) {
+				if updated, err := sjson.SetBytes([]byte(itemResult.Raw), "contentIndex", ci); err == nil {
+					normalizedItem = gjson.ParseBytes(updated)
+				}
+			}
+			if antigravityRequestHasThoughtSignatureAt(payload, normalizedItem) {
 				continue
 			}
+			item = []byte(normalizedItem.Raw)
 		default:
 			continue
 		}
@@ -423,8 +431,13 @@ func insertAntigravityReasoningReplayItems(payload []byte, items [][]byte) ([]by
 					continue
 				}
 			}
-			path := antigravityReplayPartWritePath(out, ci, pi) + ".thoughtSignature"
-			updated, err := sjson.SetBytes(out, path, sig)
+			var updated []byte
+			var err error
+			if exists {
+				updated, err = sjson.SetBytes(out, partPath+".thoughtSignature", sig)
+			} else {
+				updated, err = sjson.SetBytes(out, antigravityReplayPartWritePath(out, ci, pi), map[string]any{"thoughtSignature": sig})
+			}
 			if err != nil {
 				continue
 			}

--- a/pkg/llmproxy/executor/claude_executor.go
+++ b/pkg/llmproxy/executor/claude_executor.go
@@ -721,7 +721,6 @@ func extractAndRemoveBetas(body []byte) ([]string, []byte) {
 	var betas []string
 	if betasResult.IsArray() {
 		for _, item := range betasResult.Array() {
-			// Only string items are valid betas; ignore malformed (numbers, bools, objects).
 			if item.Type != gjson.String {
 				continue
 			}
@@ -729,11 +728,10 @@ func extractAndRemoveBetas(body []byte) ([]string, []byte) {
 				betas = append(betas, s)
 			}
 		}
-	} else if betasResult.Type == gjson.String {
-		// Comma-separated string form: split, trim, and drop empty segments.
-		for _, part := range strings.Split(betasResult.String(), ",") {
-			if s := strings.TrimSpace(part); s != "" {
-				betas = append(betas, s)
+	} else if s := strings.TrimSpace(betasResult.String()); s != "" {
+		for _, part := range strings.Split(s, ",") {
+			if beta := strings.TrimSpace(part); beta != "" {
+				betas = append(betas, beta)
 			}
 		}
 	}

--- a/pkg/llmproxy/executor/codex_websockets_executor.go
+++ b/pkg/llmproxy/executor/codex_websockets_executor.go
@@ -457,6 +457,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		return nil, err
 	}
 
+	body, _ = sjson.SetBytes(body, "model", baseModel)
 	requestedModel := payloadRequestedModel(opts, req.Model)
 	body = applyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, body, requestedModel)
 	body, _ = sjson.SetBytes(body, "model", baseModel)

--- a/pkg/llmproxy/executor/kiro_streaming.go
+++ b/pkg/llmproxy/executor/kiro_streaming.go
@@ -2886,12 +2886,10 @@ func (e *KiroExecutor) CloseExecutionSession(sessionID string) {}
 
 // getAccountKey returns a unique key for rate limiting and cooldown tracking.
 func getAccountKey(auth *cliproxyauth.Auth) string {
-	var clientID, refreshToken string
-	if auth != nil {
-		clientID = getAuthValue(auth, "client_id")
-		refreshToken = getAuthValue(auth, "refresh_token")
+	if auth == nil {
+		return kiroauth.GetAccountKey("", "")
 	}
-	return kiroauth.GetAccountKey(clientID, refreshToken)
+	return kiroauth.GetAccountKey(getAuthValue(auth, "client_id"), getAuthValue(auth, "refresh_token"))
 }
 
 // fetchAndSaveProfileArn fetches the IAM profile ARN for the authenticated user and saves it to the auth record.

--- a/pkg/llmproxy/executor/payload_helpers.go
+++ b/pkg/llmproxy/executor/payload_helpers.go
@@ -39,7 +39,7 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	// Apply default rules: first write wins per field across all matching rules.
 	for i := range rules.Default {
 		rule := &rules.Default[i]
-		if !payloadRuleApplies(rule.Models, protocol, candidates) {
+		if !payloadPayloadRuleMatches(rule.Models, protocol, candidates) {
 			continue
 		}
 		for path, value := range rule.Params {
@@ -47,16 +47,13 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 			if fullPath == "" {
 				continue
 			}
-			if _, ok := appliedDefaults[fullPath]; ok {
+			if originalValue := gjson.GetBytes(source, fullPath); originalValue.Exists() {
+				if updated, errSet := sjson.SetRawBytes(out, fullPath, []byte(originalValue.Raw)); errSet == nil {
+					out = updated
+				}
 				continue
 			}
-			// When the field already exists in the source payload, defaults must not
-			// override the caller's value; restore the source value into the output.
-			if existing := gjson.GetBytes(source, fullPath); existing.Exists() {
-				if updated, errSet := sjson.SetRawBytes(out, fullPath, []byte(existing.Raw)); errSet == nil {
-					out = updated
-					appliedDefaults[fullPath] = struct{}{}
-				}
+			if _, ok := appliedDefaults[fullPath]; ok {
 				continue
 			}
 			updated, errSet := sjson.SetBytes(out, fullPath, value)
@@ -70,7 +67,7 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	// Apply default raw rules: first write wins per field across all matching rules.
 	for i := range rules.DefaultRaw {
 		rule := &rules.DefaultRaw[i]
-		if !payloadRuleApplies(rule.Models, protocol, candidates) {
+		if !payloadPayloadRuleMatches(rule.Models, protocol, candidates) {
 			continue
 		}
 		for path, value := range rule.Params {
@@ -78,7 +75,10 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 			if fullPath == "" {
 				continue
 			}
-			if gjson.GetBytes(source, fullPath).Exists() {
+			if originalValue := gjson.GetBytes(source, fullPath); originalValue.Exists() {
+				if updated, errSet := sjson.SetRawBytes(out, fullPath, []byte(originalValue.Raw)); errSet == nil {
+					out = updated
+				}
 				continue
 			}
 			if _, ok := appliedDefaults[fullPath]; ok {
@@ -99,7 +99,7 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	// Apply override rules: last write wins per field across all matching rules.
 	for i := range rules.Override {
 		rule := &rules.Override[i]
-		if !payloadRuleApplies(rule.Models, protocol, candidates) {
+		if !payloadPayloadRuleMatches(rule.Models, protocol, candidates) {
 			continue
 		}
 		for path, value := range rule.Params {
@@ -117,7 +117,7 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	// Apply override raw rules: last write wins per field across all matching rules.
 	for i := range rules.OverrideRaw {
 		rule := &rules.OverrideRaw[i]
-		if !payloadRuleApplies(rule.Models, protocol, candidates) {
+		if !payloadPayloadRuleMatches(rule.Models, protocol, candidates) {
 			continue
 		}
 		for path, value := range rule.Params {
@@ -139,9 +139,7 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	// Apply filter rules: remove matching paths from payload.
 	for i := range rules.Filter {
 		rule := &rules.Filter[i]
-		// Filter rules are never applied unconditionally: dropping fields requires an
-		// explicit model match to avoid accidentally stripping payloads globally.
-		if !payloadModelRulesMatch(rule.Models, protocol, candidates) {
+		if !payloadFilterRuleMatches(rule.Models, protocol, candidates) {
 			continue
 		}
 		for _, path := range rule.Params {
@@ -159,12 +157,16 @@ func applyPayloadConfigWithRoot(cfg *config.Config, model, protocol, root string
 	return out
 }
 
-// payloadRuleApplies reports whether a payload rule with the given model rules
-// should be applied. An empty model-rule set means the rule is unconditional and
-// applies to every model/protocol; otherwise model/protocol matching is used.
-func payloadRuleApplies(rules []config.PayloadModelRule, protocol string, models []string) bool {
+func payloadPayloadRuleMatches(rules []config.PayloadModelRule, protocol string, models []string) bool {
 	if len(rules) == 0 {
 		return true
+	}
+	return payloadModelRulesMatch(rules, protocol, models)
+}
+
+func payloadFilterRuleMatches(rules []config.PayloadModelRule, protocol string, models []string) bool {
+	if len(rules) == 0 {
+		return false
 	}
 	return payloadModelRulesMatch(rules, protocol, models)
 }
@@ -178,36 +180,24 @@ func payloadModelRulesMatch(rules []config.PayloadModelRule, protocol string, mo
 	if len(models) == 0 {
 		for _, entry := range rules {
 			name := strings.TrimSpace(entry.Name)
+			if ep := strings.TrimSpace(entry.Protocol); ep != "" && (protocol == "" || !strings.EqualFold(ep, protocol)) {
+				continue
+			}
 			if name == "" {
-				// Empty Name means unconditional rule - applies to all models, but a
-				// declared protocol must still match when both sides are present.
-				if ep := strings.TrimSpace(entry.Protocol); ep != "" && protocol != "" && !strings.EqualFold(ep, protocol) {
-					continue
-				}
+				// Empty Name means unconditional rule - applies to all models.
 				return true
 			}
 		}
 		return false
 	}
-	// Unconditional (empty-Name) entries apply to any model, subject to a protocol
-	// match when both the rule and request declare one.
-	for _, entry := range rules {
-		if strings.TrimSpace(entry.Name) != "" {
-			continue
-		}
-		if ep := strings.TrimSpace(entry.Protocol); ep != "" && protocol != "" && !strings.EqualFold(ep, protocol) {
-			continue
-		}
-		return true
-	}
 	for _, model := range models {
 		for _, entry := range rules {
 			name := strings.TrimSpace(entry.Name)
-			if name == "" {
+			if ep := strings.TrimSpace(entry.Protocol); ep != "" && (protocol == "" || !strings.EqualFold(ep, protocol)) {
 				continue
 			}
-			if ep := strings.TrimSpace(entry.Protocol); ep != "" && protocol != "" && !strings.EqualFold(ep, protocol) {
-				continue
+			if name == "" {
+				return true
 			}
 			if matchModelPattern(name, model) {
 				return true
@@ -243,17 +233,13 @@ func payloadModelCandidates(model, requestedModel string) []string {
 	if requestedModel != "" {
 		parsed := thinking.ParseSuffix(requestedModel)
 		base := strings.TrimSpace(parsed.ModelName)
-		// Strip an additional "+alias" segment (for example "model+thinking") so the
-		// underlying base model name is also offered as a candidate.
-		if idx := strings.Index(base, "+"); idx >= 0 {
-			if trimmed := strings.TrimSpace(base[:idx]); trimmed != "" {
-				addCandidate(trimmed)
-			}
+		if !parsed.HasSuffix {
+			base = strings.TrimSpace(strings.TrimSuffix(requestedModel, "+thinking"))
 		}
 		if base != "" {
 			addCandidate(base)
 		}
-		if parsed.HasSuffix {
+		if parsed.HasSuffix || base != requestedModel {
 			addCandidate(requestedModel)
 		}
 	}

--- a/pkg/llmproxy/runtime/executor/antigravity_executor.go
+++ b/pkg/llmproxy/runtime/executor/antigravity_executor.go
@@ -108,8 +108,26 @@ type antigravityKVClient interface {
 	KVDel(ctx context.Context, keys ...string) (int64, error)
 }
 
-var currentAntigravityKVClient = func() (antigravityKVClient, bool, error) {
-	return homekv.CurrentKVClient()
+var (
+	currentAntigravityKVClientMu sync.RWMutex
+	currentAntigravityKVClient   = func() (antigravityKVClient, bool, error) {
+		return homekv.CurrentKVClient()
+	}
+)
+
+func getAntigravityKVClient() (antigravityKVClient, bool, error) {
+	currentAntigravityKVClientMu.RLock()
+	provider := currentAntigravityKVClient
+	currentAntigravityKVClientMu.RUnlock()
+	return provider()
+}
+
+func setAntigravityKVClient(provider func() (antigravityKVClient, bool, error)) func() (antigravityKVClient, bool, error) {
+	currentAntigravityKVClientMu.Lock()
+	previous := currentAntigravityKVClient
+	currentAntigravityKVClient = provider
+	currentAntigravityKVClientMu.Unlock()
+	return previous
 }
 
 type antigravityCreditsBalance struct {
@@ -151,7 +169,7 @@ func antigravityAuthHasCreditsRequired(ctx context.Context, auth *cliproxyauth.A
 		return hint.Available, nil
 	}
 
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return false, errClient
@@ -1868,7 +1886,7 @@ func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Con
 		return
 	}
 
-	if client, homeMode, errClient := currentAntigravityKVClient(); homeMode {
+	if client, homeMode, errClient := getAntigravityKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("antigravity executor: home kv best-effort refresh lock failed prefix=cpa:antigravity:*: %v", errClient)
 			return
@@ -2565,7 +2583,7 @@ func antigravityIsInShortCooldown(auth *cliproxyauth.Auth, modelName string, now
 
 func antigravityIsInShortCooldownRequired(ctx context.Context, auth *cliproxyauth.Auth, modelName string, now time.Time) (bool, time.Duration, error) {
 	kvKey := antigravityShortCooldownKVKey(auth, modelName)
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return false, 0, errClient
@@ -2620,7 +2638,7 @@ func markAntigravityShortCooldown(auth *cliproxyauth.Auth, modelName string, now
 
 func markAntigravityShortCooldownRequired(ctx context.Context, auth *cliproxyauth.Auth, modelName string, now time.Time, duration time.Duration) error {
 	kvKey := antigravityShortCooldownKVKey(auth, modelName)
-	client, homeMode, errClient := currentAntigravityKVClient()
+	client, homeMode, errClient := getAntigravityKVClient()
 	if homeMode {
 		if errClient != nil {
 			return errClient
@@ -2652,7 +2670,7 @@ func storeAntigravityCreditsBalanceBestEffort(authID string, bal antigravityCred
 	if authID == "" {
 		return
 	}
-	if client, homeMode, errClient := currentAntigravityKVClient(); homeMode {
+	if client, homeMode, errClient := getAntigravityKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("antigravity executor: home kv best-effort credits balance set failed prefix=cpa:antigravity:*: %v", errClient)
 			return

--- a/pkg/llmproxy/runtime/executor/antigravity_executor_credits_test.go
+++ b/pkg/llmproxy/runtime/executor/antigravity_executor_credits_test.go
@@ -21,10 +21,17 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
-	antigravityCreditsFailureByAuth = sync.Map{}
-	antigravityShortCooldownByAuth = sync.Map{}
-	antigravityCreditsBalanceByAuth = sync.Map{}
-	antigravityCreditsHintRefreshByID = sync.Map{}
+	clearSyncMap(&antigravityCreditsFailureByAuth)
+	clearSyncMap(&antigravityShortCooldownByAuth)
+	clearSyncMap(&antigravityCreditsBalanceByAuth)
+	clearSyncMap(&antigravityCreditsHintRefreshByID)
+}
+
+func clearSyncMap(m *sync.Map) {
+	m.Range(func(key, _ any) bool {
+		m.Delete(key)
+		return true
+	})
 }
 
 type fakeAntigravityKVClient struct {
@@ -108,12 +115,11 @@ func (c *fakeAntigravityKVClient) KVDel(_ context.Context, keys ...string) (int6
 
 func useFakeAntigravityKVClient(t *testing.T, client *fakeAntigravityKVClient, homeMode bool, errClient error) {
 	t.Helper()
-	previous := currentAntigravityKVClient
-	currentAntigravityKVClient = func() (antigravityKVClient, bool, error) {
+	previous := setAntigravityKVClient(func() (antigravityKVClient, bool, error) {
 		return client, homeMode, errClient
-	}
+	})
 	t.Cleanup(func() {
-		currentAntigravityKVClient = previous
+		setAntigravityKVClient(previous)
 	})
 }
 

--- a/pkg/llmproxy/store/gitstore.go
+++ b/pkg/llmproxy/store/gitstore.go
@@ -467,24 +467,10 @@ func (s *GitTokenStore) PersistAuthFiles(_ context.Context, message string, path
 }
 
 func (s *GitTokenStore) resolveDeletePath(id string) (string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", fmt.Errorf("auth filestore: id is empty")
+	if filepath.IsAbs(strings.TrimSpace(id)) {
+		return "", fmt.Errorf("auth filestore: auth path %s outside managed directory", id)
 	}
-	dir := s.baseDirSnapshot()
-	if dir == "" {
-		return "", fmt.Errorf("auth filestore: directory not configured")
-	}
-	// Absolute identifiers and traversal are not permitted: every managed auth
-	// file must resolve to a location inside the base directory.
-	if filepath.IsAbs(id) {
-		return "", fmt.Errorf("git token store: absolute delete id %q not permitted", id)
-	}
-	clean := filepath.Clean(filepath.FromSlash(id))
-	if clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("git token store: delete id %q escapes managed directory", id)
-	}
-	return ensurePathWithinDir(filepath.Join(dir, clean), dir, "git token store")
+	return resolveManagedAuthPath(s.baseDirSnapshot(), id, "auth filestore", false)
 }
 
 func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {
@@ -550,46 +536,18 @@ func (s *GitTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error)
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")
 	}
-	dir := s.baseDirSnapshot()
 	if auth.Attributes != nil {
 		if p := strings.TrimSpace(auth.Attributes["path"]); p != "" {
-			if dir == "" {
-				return p, nil
-			}
-			resolved := p
-			if !filepath.IsAbs(resolved) {
-				resolved = filepath.Join(dir, resolved)
-			}
-			return ensurePathWithinDir(resolved, dir, "git token store")
+			return resolveManagedAuthPath(s.baseDirSnapshot(), p, "auth filestore", false)
 		}
 	}
 	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
-		if dir == "" {
-			if filepath.IsAbs(fileName) {
-				return fileName, nil
-			}
-			return fileName, nil
-		}
-		resolved := fileName
-		if !filepath.IsAbs(resolved) {
-			resolved = filepath.Join(dir, resolved)
-		}
-		return ensurePathWithinDir(resolved, dir, "git token store")
+		return resolveManagedAuthPath(s.baseDirSnapshot(), fileName, "auth filestore", false)
 	}
 	if auth.ID == "" {
 		return "", fmt.Errorf("auth filestore: missing id")
 	}
-	if dir == "" {
-		if filepath.IsAbs(auth.ID) {
-			return auth.ID, nil
-		}
-		return "", fmt.Errorf("auth filestore: directory not configured")
-	}
-	resolved := auth.ID
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(dir, resolved)
-	}
-	return ensurePathWithinDir(resolved, dir, "git token store")
+	return resolveManagedAuthPath(s.baseDirSnapshot(), auth.ID, "auth filestore", false)
 }
 
 func (s *GitTokenStore) labelFor(metadata map[string]any) string {

--- a/pkg/llmproxy/store/objectstore.go
+++ b/pkg/llmproxy/store/objectstore.go
@@ -521,11 +521,7 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 	}
 	if auth.Attributes != nil {
 		if path := strings.TrimSpace(auth.Attributes["path"]); path != "" {
-			resolved := path
-			if !filepath.IsAbs(resolved) {
-				resolved = filepath.Join(s.authDir, resolved)
-			}
-			return ensurePathWithinDir(resolved, s.authDir, "object store")
+			return resolveManagedAuthPath(s.authDir, path, "object store", false)
 		}
 	}
 	fileName := strings.TrimSpace(auth.FileName)
@@ -535,10 +531,7 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 	if fileName == "" {
 		return "", fmt.Errorf("object store: auth %s missing filename", auth.ID)
 	}
-	if !strings.HasSuffix(strings.ToLower(fileName), ".json") {
-		fileName += ".json"
-	}
-	return ensurePathWithinDir(filepath.Join(s.authDir, fileName), s.authDir, "object store")
+	return resolveManagedAuthPath(s.authDir, fileName, "object store", true)
 }
 
 func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
@@ -546,21 +539,7 @@ func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("object store: id is empty")
 	}
-	// Absolute paths are honored as-is; callers must ensure they point inside the mirror.
-	if filepath.IsAbs(id) {
-		return id, nil
-	}
-	// Treat any non-absolute id (including nested like "team/foo") as relative to the mirror authDir.
-	// Normalize separators and guard against path traversal.
-	clean := filepath.Clean(filepath.FromSlash(id))
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("object store: invalid auth identifier %s", id)
-	}
-	// Ensure .json suffix.
-	if !strings.HasSuffix(strings.ToLower(clean), ".json") {
-		clean += ".json"
-	}
-	return filepath.Join(s.authDir, clean), nil
+	return resolveManagedAuthPath(s.authDir, id, "object store", true)
 }
 
 func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {

--- a/pkg/llmproxy/store/path_resolver.go
+++ b/pkg/llmproxy/store/path_resolver.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func resolveManagedAuthPath(baseDir, value, scope string, addJSONSuffix bool) (string, error) {
+	baseDir = strings.TrimSpace(baseDir)
+	if baseDir == "" {
+		return "", fmt.Errorf("%s: auth directory not configured", scope)
+	}
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("%s: resolve auth directory: %w", scope, err)
+	}
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return "", fmt.Errorf("%s: auth path is empty", scope)
+	}
+	if hasTraversalComponent(raw) {
+		return "", fmt.Errorf("%s: auth path %s escapes outside managed directory", scope, value)
+	}
+	clean := filepath.Clean(filepath.FromSlash(raw))
+	if clean == "." || clean == ".." {
+		return "", fmt.Errorf("%s: auth path is invalid", scope)
+	}
+	if addJSONSuffix && !strings.HasSuffix(strings.ToLower(clean), ".json") {
+		clean += ".json"
+	}
+	path := clean
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseAbs, path)
+	}
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(baseAbs, path)
+	if err != nil {
+		return "", fmt.Errorf("%s: resolve auth path: %w", scope, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%s: auth path %s escapes outside managed directory", scope, value)
+	}
+	return path, nil
+}
+
+func hasTraversalComponent(path string) bool {
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	for _, component := range strings.Split(normalized, "/") {
+		if component == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/llmproxy/store/postgresstore.go
+++ b/pkg/llmproxy/store/postgresstore.go
@@ -459,12 +459,8 @@ func (s *PostgresStore) syncAuthFromDatabase(ctx context.Context) error {
 	}
 	defer rows.Close()
 
-	// Mirror database rows onto the local spool without wiping it: local-only
-	// files (not represented in the database) are preserved. Per-row failures
-	// (e.g. a directory occupying a target file path) are logged and skipped so
-	// one bad row cannot abort mirroring of the remaining healthy rows.
 	if err = os.MkdirAll(s.authDir, 0o700); err != nil {
-		return fmt.Errorf("postgres store: recreate auth directory: %w", err)
+		return fmt.Errorf("postgres store: create auth directory: %w", err)
 	}
 
 	for rows.Next() {
@@ -480,17 +476,15 @@ func (s *PostgresStore) syncAuthFromDatabase(ctx context.Context) error {
 			log.WithError(errPath).Warnf("postgres store: skipping auth %s outside spool", id)
 			continue
 		}
-		if errMk := os.MkdirAll(filepath.Dir(path), 0o700); errMk != nil {
-			log.WithError(errMk).Warnf("postgres store: skipping auth %s: create subdir failed", id)
-			continue
+		if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return fmt.Errorf("postgres store: create auth subdir: %w", err)
 		}
 		if info, errStat := os.Stat(path); errStat == nil && info.IsDir() {
-			log.Warnf("postgres store: skipping auth %s: target path is a directory", id)
+			log.Warnf("postgres store: skipping auth %s because local path is a directory", id)
 			continue
 		}
-		if errWrite := os.WriteFile(path, []byte(payload), 0o600); errWrite != nil {
-			log.WithError(errWrite).Warnf("postgres store: skipping auth %s: write failed", id)
-			continue
+		if err = os.WriteFile(path, []byte(payload), 0o600); err != nil {
+			return fmt.Errorf("postgres store: write auth file: %w", err)
 		}
 	}
 	if err = rows.Err(); err != nil {
@@ -574,43 +568,20 @@ func (s *PostgresStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, error)
 	}
 	if auth.Attributes != nil {
 		if p := strings.TrimSpace(auth.Attributes["path"]); p != "" {
-			return s.constrainToAuthDir(p)
+			return resolveManagedAuthPath(s.authDir, p, "postgres store", false)
 		}
 	}
 	if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
-		return s.constrainToAuthDir(fileName)
+		return resolveManagedAuthPath(s.authDir, fileName, "postgres store", false)
 	}
 	if auth.ID == "" {
 		return "", fmt.Errorf("postgres store: missing id")
 	}
-	return s.constrainToAuthDir(auth.ID)
+	return resolveManagedAuthPath(s.authDir, auth.ID, "postgres store", false)
 }
 
 func (s *PostgresStore) resolveDeletePath(id string) (string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", fmt.Errorf("postgres store: id is empty")
-	}
-	return s.constrainToAuthDir(id)
-}
-
-// constrainToAuthDir resolves an auth identifier or path relative to authDir and
-// rejects any value that escapes the managed auth directory (absolute paths
-// outside it or traversal segments).
-func (s *PostgresStore) constrainToAuthDir(value string) (string, error) {
-	resolved := value
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(s.authDir, filepath.FromSlash(resolved))
-	}
-	clean := filepath.Clean(resolved)
-	rel, err := filepath.Rel(s.authDir, clean)
-	if err != nil {
-		return "", fmt.Errorf("postgres store: compute relative path: %w", err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", fmt.Errorf("postgres store: path %s outside managed directory", value)
-	}
-	return clean, nil
+	return resolveManagedAuthPath(s.authDir, id, "postgres store", false)
 }
 
 func (s *PostgresStore) relativeAuthID(path string) (string, error) {

--- a/pkg/llmproxy/watcher/watcher.go
+++ b/pkg/llmproxy/watcher/watcher.go
@@ -80,6 +80,12 @@ type AuthUpdate struct {
 	Auth   *coreauth.Auth
 }
 
+func (w *Watcher) LastConfigHash() string {
+	w.clientsMutex.RLock()
+	defer w.clientsMutex.RUnlock()
+	return w.lastConfigHash
+}
+
 const (
 	// replaceCheckDelay is a short delay to allow atomic replace (rename) to settle
 	// before deciding whether a Remove event indicates a real deletion.

--- a/pkg/llmproxy/watcher/watcher_test.go
+++ b/pkg/llmproxy/watcher/watcher_test.go
@@ -1508,6 +1508,7 @@ func TestNormalizeAuthNil(t *testing.T) {
 
 // stubStore implements coreauth.Store plus watcher-specific persistence helpers.
 type stubStore struct {
+	mu              sync.Mutex
 	authDir         string
 	cfgPersisted    int32
 	authPersisted   int32
@@ -1526,11 +1527,19 @@ func (s *stubStore) PersistConfig(context.Context) error {
 }
 func (s *stubStore) PersistAuthFiles(_ context.Context, message string, paths ...string) error {
 	atomic.AddInt32(&s.authPersisted, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lastAuthMessage = message
-	s.lastAuthPaths = paths
+	s.lastAuthPaths = append([]string(nil), paths...)
 	return nil
 }
 func (s *stubStore) AuthDir() string { return s.authDir }
+
+func (s *stubStore) LastAuth() (string, []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastAuthMessage, append([]string(nil), s.lastAuthPaths...)
+}
 
 func TestNewWatcherDetectsPersisterAndAuthDir(t *testing.T) {
 	tmp := t.TempDir()
@@ -1567,11 +1576,12 @@ func TestPersistConfigAndAuthAsyncInvokePersister(t *testing.T) {
 	if atomic.LoadInt32(&store.authPersisted) != 1 {
 		t.Fatalf("expected PersistAuthFiles to be called once, got %d", store.authPersisted)
 	}
-	if store.lastAuthMessage != "msg" {
-		t.Fatalf("unexpected auth message: %s", store.lastAuthMessage)
+	message, paths := store.LastAuth()
+	if message != "msg" {
+		t.Fatalf("unexpected auth message: %s", message)
 	}
-	if len(store.lastAuthPaths) != 2 || store.lastAuthPaths[0] != "a" || store.lastAuthPaths[1] != "b" {
-		t.Fatalf("unexpected filtered paths: %#v", store.lastAuthPaths)
+	if len(paths) != 2 || paths[0] != "a" || paths[1] != "b" {
+		t.Fatalf("unexpected filtered paths: %#v", paths)
 	}
 }
 
@@ -1599,7 +1609,7 @@ func TestScheduleConfigReloadDebounces(t *testing.T) {
 	if atomic.LoadInt32(&reloads) != 1 {
 		t.Fatalf("expected single debounced reload, got %d", reloads)
 	}
-	if w.lastConfigHash == "" {
+	if w.LastConfigHash() == "" {
 		t.Fatal("expected lastConfigHash to be set after reload")
 	}
 }

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -715,6 +715,13 @@ func TestHandlerStreamInterceptorInitializesHeadersBeforeReturn(t *testing.T) {
 	dataChan := result.dataChan
 	upstreamHeaders := result.upstreamHeaders
 	errChan := result.errChan
+	firstChunk, ok := <-dataChan
+	if !ok {
+		t.Fatal("data channel closed before first chunk")
+	}
+	if string(firstChunk) != "payload" {
+		t.Fatalf("first chunk = %q, want payload", firstChunk)
+	}
 	if upstreamHeaders.Get("X-Init") != "plugin" {
 		t.Fatalf("upstream headers before first payload = %#v, want initialized plugin header", upstreamHeaders)
 	}


### PR DESCRIPTION
## **User description**
Follow-up to merged PR #1034.

## Summary
- hardens managed auth path resolution for file/object/postgres auth stores
- restores/keeps executor regression fixes for Antigravity replay, Codex websocket model normalization, Kiro account keys, and payload model matching
- preserves OAuth success page escaping and response/thinking regression fixes on top of merged upstream-port main

## Verification
- go test ./pkg/llmproxy/executor -count=1 -timeout=240s (469 passed, 0 failed)
- go test ./pkg/llmproxy/auth/base ./pkg/llmproxy/auth/kimi ./pkg/llmproxy/auth/qwen ./pkg/llmproxy/store ./pkg/llmproxy/auth/diff ./pkg/llmproxy/auth/synthesizer -count=1 -timeout=180s (143 passed, 0 failed)
- go test ./pkg/llmproxy/api/handlers/management -run 'TestPutConfigYAMLReadOnlyWriteAppliesRuntimeConfig|TestAPICallTransport|TestInstallPluginFromStore' -count=1 -timeout=120s\n- go test ./pkg/llmproxy/pluginstore ./pkg/llmproxy/api/modules/amp -run 'Install|DedicatedProviderModels|RegisterProviderAliases' -count=1 -timeout=120s\n- go test ./pkg/llmproxy/translator/openai/openai/responses ./test -run 'Annotations|OpenAIChat|TestOpenAIToResponses_.*Annotations|TestThinkingE2EMatrix_Suffix' -count=1 -timeout=180s\n- git diff --check


___

## **CodeAnt-AI Description**
**Harden auth handling and restore several upstream behavior fixes**

### What Changed
- File, object, and database-backed auth paths are now rejected unless they stay inside the managed auth directory, which blocks unsafe path inputs and prevents files from being written or deleted outside the expected location
- Gemini CLI file credentials are now handled as one disabled primary entry plus active per-project entries, instead of being ignored when project IDs are missing or expanded in the old way
- OAuth success pages now always escape the platform URL before showing it to users
- Payload rules now keep caller-provided fields intact when defaults are applied, while filter rules only run when they have an explicit match
- Antigravity replay and retry behavior now accepts shorter signatures, handles 429 resource exhaustion responses more reliably, and preserves replayed thought signatures in more cases
- Codex, Claude, and Kiro request handling now normalizes models, beta values, and account keys more consistently

### Impact
`✅ Fewer unsafe auth file writes`
`✅ More reliable Gemini CLI account loading`
`✅ Clearer OAuth success pages`
`✅ Fewer replay and request handling regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
